### PR TITLE
CHAT-140: No encoding chat's message when saving meeting notes as wiki

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
@@ -304,6 +304,13 @@ public class ChatApplication
   public Response.Content saveWiki(String targetFullname, String content) {
     // Clean targetFullName
     targetFullname = ChatUtils.cleanString(targetFullname);
+    content = content.replaceAll("&#38", "&");
+    content = content.replaceAll("&lt;", "<");
+    content = content.replaceAll("&gt;", ">");
+    content = content.replaceAll("&quot;","\"");
+    content = content.replaceAll("<br/>","\n");
+    content = content.replaceAll("&#92","\\\\");
+    content = content.replaceAll("  ","\t");
 
     SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH-mm");
     String group = null, title = null, path="";


### PR DESCRIPTION
Problem:
- Encode some special characters (&,<,>, ..) when saving to mongoDB but missing decode after getting message's content from mongoDB to save as$
How to fix:
- Decode message's content before saving as wiki.