### PR TITLE
CHAT-139: Meeting notes should be saved in space wiki

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
@@ -302,8 +302,6 @@ public class ChatApplication
   @Ajax
   @Resource
   public Response.Content saveWiki(String targetFullname, String content) {
-    // Clean targetFullName
-    targetFullname = ChatUtils.cleanString(targetFullname);
 
     SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH-mm");
     String group = null, title = null, path="";


### PR DESCRIPTION
Fix description:
* Problem: Return null when getSpaceByDisplayName in saveWiki(String targetFullname, String content) function of ChatApplication.java.
Caused by: Function getSpaceByDisplayName uses groupId as parameter insteads of space's display name
* How to fix?
Use the correct parameter when getSpaceByDisplayName: Removed line: targetFullname = ChatUtils.cleanString(targetFullname); in function saveWiki(String targetFullname, String content) of ChatApplication.java