### PR TITLE
CHAT-144: Display incorrect when team's name contains special characters

### DIFF
--- a/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -576,7 +576,7 @@ public class ChatServer
 
       }
 
-      jsonObject.put("name", StringEscapeUtils.escapeHtml4(teamName));
+      jsonObject.put("name", teamName);
       jsonObject.put("room", room);
 
     }


### PR DESCRIPTION
Fix description: Remove escapeHtml4 before put to json list for viewing.