### PR TITLE
CHAT-168: Broken message encoding when using Apache front-end

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -132,7 +132,7 @@ ChatRoom.prototype.sendFullMessage = function(user, token, targetUser, room, msg
       "targetUser": targetUser,
       "room": room,
       "message": encodeURIComponent(msg),
-      "options": JSON.stringify(options),
+      "options": encodeURIComponent(JSON.stringify(options)),
       "token": token,
       "timestamp": new Date().getTime(),
       "isSystem": isSystemMessage

--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -131,7 +131,7 @@ ChatRoom.prototype.sendFullMessage = function(user, token, targetUser, room, msg
     data: {"user": user,
       "targetUser": targetUser,
       "room": room,
-      "message": msg,
+      "message": encodeURIComponent(msg),
       "options": JSON.stringify(options),
       "token": token,
       "timestamp": new Date().getTime(),

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1267,7 +1267,7 @@ ChatApplication.prototype.editMessage = function(id, newMessage, callback) {
       "user": this.username,
       "token": this.token,
       "messageId": id,
-      "message": newMessage
+      "message": encodeURIComponent(newMessage)
     },
 
     success:function(response){
@@ -1296,7 +1296,7 @@ ChatApplication.prototype.saveTeamRoom = function(teamName, room, users, callbac
   jqchat.ajax({
     url: this.jzSaveTeamRoom,
     dataType: "json",
-    data: {"teamName": teamName,
+    data: {"teamName": encodeURIComponent(teamName),
       "room": room,
       "users": users,
       "user": this.username,

--- a/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -22,14 +22,12 @@ package org.exoplatform.chat.server;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.util.JSON;
-
 import juzu.Path;
 import juzu.Resource;
 import juzu.Response;
 import juzu.Route;
 import juzu.View;
 import juzu.template.Template;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.exoplatform.chat.listener.GuiceManager;
@@ -140,20 +138,14 @@ public class ChatServer
           if (!roomMembers.contains(user)) {
             return Response.content(403, "Petit malin !");
           }
-        }
-        
+        }        
         try {
           message = URLDecoder.decode(message,"UTF-8");
-        } catch (UnsupportedEncodingException e) {
-          LOG.info("Cannot decode message: " + message);
-        }
-        try {
           options = URLDecoder.decode(options,"UTF-8");
         } catch (UnsupportedEncodingException e) {
-          LOG.info("Cannot decode message: " + options);
+          // Chat server cannot do anything in this case
+          // Get original value
         }
-        
-
         if (isSystem==null) isSystem="false";
         chatService.write(message, user, room, isSystem, options);
         if (!targetUser.startsWith(ChatService.EXTERNAL_PREFIX))
@@ -397,7 +389,8 @@ public class ChatServer
       try {
         message = URLDecoder.decode(message,"UTF-8");
       } catch (UnsupportedEncodingException e) {
-        LOG.info("Cannot decode message: " + message);
+        // Chat server cannot do anything in this case
+        // Get original value
       }
       chatService.edit(room, user, messageId, message);
     }

--- a/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -22,12 +22,14 @@ package org.exoplatform.chat.server;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.util.JSON;
+
 import juzu.Path;
 import juzu.Resource;
 import juzu.Response;
 import juzu.Route;
 import juzu.View;
 import juzu.template.Template;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.exoplatform.chat.listener.GuiceManager;
@@ -53,7 +55,10 @@ import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -136,6 +141,18 @@ public class ChatServer
             return Response.content(403, "Petit malin !");
           }
         }
+        
+        try {
+          message = URLDecoder.decode(message,"UTF-8");
+        } catch (UnsupportedEncodingException e) {
+          LOG.info("Cannot decode message: " + message);
+        }
+        try {
+          options = URLDecoder.decode(options,"UTF-8");
+        } catch (UnsupportedEncodingException e) {
+          LOG.info("Cannot decode message: " + options);
+        }
+        
 
         if (isSystem==null) isSystem="false";
         chatService.write(message, user, room, isSystem, options);
@@ -377,6 +394,11 @@ public class ChatServer
     }
     try
     {
+      try {
+        message = URLDecoder.decode(message,"UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        LOG.info("Cannot decode message: " + message);
+      }
       chatService.edit(room, user, messageId, message);
     }
     catch (Exception e)
@@ -487,7 +509,7 @@ public class ChatServer
       out = roomBean.toJSON();
     }
 
-    return Response.ok(out);
+    return Response.ok(out).withMimeType("application/json; charset=UTF-8").withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
@@ -502,6 +524,11 @@ public class ChatServer
 
     try
     {
+      try {
+    	teamName = URLDecoder.decode(teamName,"UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        LOG.info("Cannot decode message: " + teamName);
+      }
       if (room==null || "".equals(room) || "---".equals(room))
       {
         room = chatService.getTeamRoom(teamName, user);

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
@@ -85,15 +85,10 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
     write(message, user, room, isSystem, null);
   }
 
-  public void write(String plainMessage, String user, String room, String isSystem, String options)
+  public void write(String message, String user, String room, String isSystem, String options)
   {
     DBCollection coll = db().getCollection(M_ROOM_PREFIX+room);
-    String message = null;
-    try {
-      message = URLDecoder.decode(plainMessage,"UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      message = plainMessage;
-    }
+    
     message = StringUtils.chomp(message);
     message = message.replaceAll("&", "&#38");
     message = message.replaceAll("<", "&lt;");

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
@@ -26,7 +26,6 @@ import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
-
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
@@ -44,9 +43,6 @@ import org.exoplatform.chat.utils.PropertyManager;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -88,7 +84,7 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
   public void write(String message, String user, String room, String isSystem, String options)
   {
     DBCollection coll = db().getCollection(M_ROOM_PREFIX+room);
-    
+
     message = StringUtils.chomp(message);
     message = message.replaceAll("&", "&#38");
     message = message.replaceAll("<", "&lt;");

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
@@ -26,6 +26,7 @@ import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
@@ -43,6 +44,9 @@ import org.exoplatform.chat.utils.PropertyManager;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -81,10 +85,15 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
     write(message, user, room, isSystem, null);
   }
 
-  public void write(String message, String user, String room, String isSystem, String options)
+  public void write(String plainMessage, String user, String room, String isSystem, String options)
   {
     DBCollection coll = db().getCollection(M_ROOM_PREFIX+room);
-
+    String message = null;
+    try {
+      message = URLDecoder.decode(plainMessage,"UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      message = plainMessage;
+    }
     message = StringUtils.chomp(message);
     message = message.replaceAll("&", "&#38");
     message = message.replaceAll("<", "&lt;");


### PR DESCRIPTION
Problem analysis
- If connecter does not declare explicitly URI Encoding, transfered message will be encoded in Latin-1

Fix description
- Encode UTF-8 String when sending message from client
- Decode String when receiving it in server