### PR TITLE
CHAT-202: Failed to upload file with name containing percent character

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -88,6 +88,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.social</groupId>
       <artifactId>social-component-core</artifactId>
       <scope>provided</scope>
@@ -141,6 +146,9 @@
       <plugin>
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>gmaven-plugin</artifactId>
+        <configuration>
+          <providerSelection>${gmaven-plugin.providerSelection}</providerSelection>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -188,6 +196,6 @@
   </build>
   <properties>
     <!-- gmaven-plugin -->
-    <gmaven-plugin.providerSelection>1.6</gmaven-plugin.providerSelection>
+    <gmaven-plugin.providerSelection>1.7</gmaven-plugin.providerSelection>
   </properties>
 </project>

--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
@@ -221,7 +221,7 @@ public class ChatApplication
 
   @Resource
   @Ajax
-  public Response.Content upload(String room, String targetUser, String targetFullname, FileItem userfile, ResourceContext resourceContext) {
+  public Response.Content upload(String room, String targetUser, String targetFullname, String encodedFileName, FileItem userfile, ResourceContext resourceContext) {
     try {
       targetFullname = URLDecoder.decode(targetFullname, "UTF-8");
     } catch (UnsupportedEncodingException e) {
@@ -243,12 +243,12 @@ public class ChatApplication
       String uuid = null;
       if (targetUser.startsWith(ChatService.SPACE_PREFIX))
       {
-        uuid = documentsData_.storeFile(userfile, targetFullname, false);
+        uuid = documentsData_.storeFile(userfile, encodedFileName, targetFullname, false);
       }
       else
       {
         remoteUser_ = resourceContext.getSecurityContext().getRemoteUser();
-        uuid = documentsData_.storeFile(userfile, remoteUser_, true);
+        uuid = documentsData_.storeFile(userfile, encodedFileName, remoteUser_, true);
         documentsData_.setPermission(uuid, targetUser);
       }
       File file = documentsData_.getNode(uuid);

--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/templates/index.gtmpl
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/templates/index.gtmpl
@@ -155,6 +155,7 @@
                     <input type="hidden" name="room" value="---" id="chat-file-room" />
                     <input type="hidden" name="targetUser" value="---" id="chat-file-target-user" />
                     <input type="hidden" name="targetFullname" value="---" id="chat-file-target-fullname" />
+                    <input type="hidden" name="encodedFileName" value="---" id="chat-encoded-file-name" />
                     <div class="uiActionBorder">
 	                    <a href="#" class="btn btn-primary chat-file-upload" type="button">
 	                      <span>&{exoplatform.chat.file.manually}</span>

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -212,8 +212,8 @@ var chatApplication = new ChatApplication();
                               +'<div class="label"><div class="label-inner">'+chatBundleData.exoplatform_chat_file_drop+'</div></div>'
                             +'</div>'
                           +'</div>';
-            $('#dropzone-container').html(dropzone);
 
+            $('#dropzone-container').html(dropzone);
             $('#dropzone').filedrop({
 //          fallback_id: 'upload_button',   // an identifier of a standard file input element
               url: chatApplication.jzUpload,              // upload handler, handles each file separately, can also be a function taking the file and returning a url
@@ -436,8 +436,11 @@ var chatApplication = new ChatApplication();
     });
 
     $("#chat-file-file").on("change", function() {
-      if ($(this).val()!=="")
+      if ($(this).val()!=="") {
+          var originalName = encodeURIComponent($(this).val().split(/(\\|\/)/g).pop());
+          $("#chat-encoded-file-name").val(originalName);
         $("#chat-file-submit").trigger("click");
+      }
     });
 
     $('.uiRightContainerArea').on('dragenter', function() {

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,9 @@
   <properties>
     <!-- 3rd party libraries versions -->
     <commons-lang3.version>3.2</commons-lang3.version>
-    <exoplatform.version>4.0.0</exoplatform.version>
-    <org.exoplatform.ecms.version>4.1.0</org.exoplatform.ecms.version>
+    <org.gatein.portal.version>3.5.x-PLF-SNAPSHOT</org.gatein.portal.version>
+    <org.exoplatform.ecms.version>4.1.x-SNAPSHOT</org.exoplatform.ecms.version>
+    <org.exoplatform.platform.version>4.1.x-SNAPSHOT</org.exoplatform.platform.version>
     <javax.enterprise.cdi.version>1.0-SP4</javax.enterprise.cdi.version>
     <juzu.version>0.6.2</juzu.version>
     <mongodb-java-driver.version>2.12.2</mongodb-java-driver.version>
@@ -113,6 +114,16 @@
         <version>${project.version}</version>
         <type>war</type>
       </dependency>
+    <dependency>
+      <groupId>org.gatein.portal</groupId>
+      <artifactId>exo.portal.component.portal</artifactId>
+      <version>${org.gatein.portal.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.gatein.portal</groupId>
+      <artifactId>exo.portal.webui.portal</artifactId>
+      <version>${org.gatein.portal.version}</version>
+    </dependency>
       <!-- Import versions from ecms project -->
       <dependency>
         <groupId>org.exoplatform.ecms</groupId>
@@ -125,7 +136,7 @@
       <dependency>
         <groupId>org.exoplatform.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>${exoplatform.version}</version>
+        <version>${org.exoplatform.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <!-- 3rd party libraries versions -->
     <commons-lang3.version>3.2</commons-lang3.version>
     <exoplatform.version>4.0.0</exoplatform.version>
+    <org.exoplatform.ecms.version>4.1.0</org.exoplatform.ecms.version>
     <javax.enterprise.cdi.version>1.0-SP4</javax.enterprise.cdi.version>
     <juzu.version>0.6.2</juzu.version>
     <mongodb-java-driver.version>2.12.2</mongodb-java-driver.version>
@@ -111,6 +112,14 @@
         <artifactId>server</artifactId>
         <version>${project.version}</version>
         <type>war</type>
+      </dependency>
+      <!-- Import versions from ecms project -->
+      <dependency>
+        <groupId>org.exoplatform.ecms</groupId>
+        <artifactId>ecms</artifactId>
+        <version>${org.exoplatform.ecms.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <!-- Import versions from platform project -->
       <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -104,6 +104,11 @@
       <version>3.2.5-PLF</version>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.juzu</groupId>
       <artifactId>juzu-bom-core</artifactId>
       <scope>provided</scope>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -92,16 +92,14 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.portal</groupId>
+      <groupId>org.gatein.portal</groupId>
       <artifactId>exo.portal.component.portal</artifactId>
       <scope>provided</scope>
-      <version>3.2.5-PLF</version>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.portal</groupId>
+      <groupId>org.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portal</artifactId>
       <scope>provided</scope>
-      <version>3.2.5-PLF</version>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.ecms</groupId>

--- a/server/src/main/java/org/exoplatform/chat/utils/ChatUtils.java
+++ b/server/src/main/java/org/exoplatform/chat/utils/ChatUtils.java
@@ -15,6 +15,7 @@ import com.ibm.icu.text.Transliterator;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.chat.services.ChatService;
+import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.resources.ResourceBundleService;
 
@@ -101,37 +102,13 @@ public class ChatUtils {
    */
   public static String cleanString(String str) {
     Transliterator accentsconverter = Transliterator.getInstance("Latin; NFD; [:Nonspacing Mark:] Remove; NFC;");
-    str = accentsconverter.transliterate(str);
-    //the character ? seems to not be changed to d by the transliterate function
-    StringBuffer cleanedStr = new StringBuffer(str.trim());
-    // delete special character
-    for(int i = 0; i < cleanedStr.length(); i++) {
-      char c = cleanedStr.charAt(i);
-      if(c == ' ') {
-        if (i > 0 && cleanedStr.charAt(i - 1) == '-') {
-          cleanedStr.deleteCharAt(i--);
-        } else {
-          c = '-';
-          cleanedStr.setCharAt(i, c);
-        }
-        continue;
-      }
-      if(i > 0 && !(Character.isLetterOrDigit(c) || c == '-')) {
-        cleanedStr.deleteCharAt(i--);
-        continue;
-      }
-      if(i > 0 && c == '-' && cleanedStr.charAt(i-1) == '-')
-        cleanedStr.deleteCharAt(i--);
+    if (str.indexOf('.') > 0) {
+      String ext = str.substring(str.lastIndexOf('.'));
+      str = accentsconverter.transliterate(str.substring(0, str.lastIndexOf('.'))).concat(ext);
+    } else {
+      str = accentsconverter.transliterate(str);
     }
-    while (StringUtils.isNotEmpty(cleanedStr.toString()) && !Character.isLetterOrDigit(cleanedStr.charAt(0))) {
-      cleanedStr.deleteCharAt(0);
-    }
-    String clean = cleanedStr.toString().toLowerCase();
-    if (clean.endsWith("-")) {
-      clean = clean.substring(0, clean.length()-1);
-    }
-
-    return clean;
+    return Text.escapeIllegalJcrChars(str);
   }
 
   public static String appRes(String key,Locale locale) {


### PR DESCRIPTION
Problem analysis
- All special characters in file name are deleted before saving in Chat server
- When file name contains percentage sign, it is unable to be escaped by URLDecoder because it leads to error syntax.

Fix description:
- When sharing file in chat, eXo Platform applies the same way to process file name with uploading file in Content Explorer
- Add a parameter to juzu request to transfer encoded file name.