### PR TITLE
CHAT-205: Accent name is not well rendered when opening chat from mini c...

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1969,7 +1969,7 @@ ChatApplication.prototype.loadRoom = function() {
 
     jqchat("#room-detail").css("display", "block");
     jqchat(".team-button").css("display", "none");
-    jqchat(".target-user-fullname").text(this.targetFullname);
+    jqchat(".target-user-fullname").text(jqchat("<div/>").html(this.targetFullname).text());
 
     if(navigator.platform.indexOf("Linux") === -1) {
       jqchat(".btn-weemo-conf").css("display", "none");

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1762,6 +1762,15 @@ ChatApplication.prototype.showRooms = function(rooms) {
             totalPeople += Math.round(room.unreadTotal);
           }
         }
+        if (chatApplication.room === room.room) {
+          var spaceFullName = jqchat("<div/>").html(room.escapedFullname).text();
+          if (chatApplication.targetFullname !== spaceFullName) {
+            jqchat('.target-user-fullname').text(spaceFullName);
+            chatApplication.targetUser = room.user;
+            chatApplication.targetFullname = spaceFullName;
+            chatApplication.loadRoom();
+          }
+        }
       }
     }
   });

--- a/server/src/main/java/org/exoplatform/chat/model/RoomBean.java
+++ b/server/src/main/java/org/exoplatform/chat/model/RoomBean.java
@@ -136,7 +136,7 @@ public class RoomBean implements Comparable<RoomBean>
   {
     JSONObject obj = new org.json.JSONObject();
     try {
-      obj.put("escapedFullname", this.getFullname());
+      obj.put("escapedFullname", this.getEscapedFullname());
       obj.put("room", this.getRoom());
       obj.put("status", this.getStatus());
       obj.put("user", this.getUser());

--- a/server/src/main/java/org/exoplatform/chat/model/RoomBean.java
+++ b/server/src/main/java/org/exoplatform/chat/model/RoomBean.java
@@ -136,7 +136,7 @@ public class RoomBean implements Comparable<RoomBean>
   {
     JSONObject obj = new org.json.JSONObject();
     try {
-      obj.put("escapedFullname", this.getEscapedFullname());
+      obj.put("escapedFullname", this.getFullname());
       obj.put("room", this.getRoom());
       obj.put("status", this.getStatus());
       obj.put("user", this.getUser());


### PR DESCRIPTION
...hat

Problem analysis
- Escape name by apache lib is not well rendered in chat room title
- When left panel is reloaded, user name is updated but this action does not refresh chat title of user-to-user chat in right panel

Fix description
- Escape string before rendering in chat title
- Trigger changing title of user-to-user chat when left panel is reloaded