### PR TITLE
CHAT-200: [Add Event] Time of event is not correct in Calendar

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
+++ b/application/src/main/java/org/exoplatform/chat/portlet/chat/ChatApplication.java
@@ -291,7 +291,7 @@ public class ChatApplication
   @Ajax
   @Resource
   public Response.Content createEvent(String space, String users, String summary, String startDate, String startTime, String endDate, String endTime) {
-    SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm");
+    SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy hh:mm a");
     try {
       calendarService_.saveEvent(remoteUser_, space, users, summary, sdf.parse(startDate + " " + startTime),
               sdf.parse(endDate + " " + endTime));


### PR DESCRIPTION
Fix description:
* Use 12 hour format when saving event