### PR TITLE
CHAT-255: Update target full name when opening a chat from mini chat

### DIFF
--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1972,7 +1972,8 @@ ChatApplication.prototype.loadRoom = function() {
 
     jqchat("#room-detail").css("display", "block");
     jqchat(".team-button").css("display", "none");
-    jqchat(".target-user-fullname").text(jqchat("<div/>").html(this.targetFullname).text());
+    this.targetFullname = jqchat("<div/>").html(this.targetFullname).text();
+    jqchat(".target-user-fullname").text(this.targetFullname);
 
     if(navigator.platform.indexOf("Linux") === -1) {
       jqchat(".btn-weemo-conf").css("display", "none");


### PR DESCRIPTION
Problem analysis
- Target Full name is in encoded HTML syntax when opening a chat from mini chat. As the result, chat server cannot get space from name.

Fix description
- Decode target full name when loading room
