### PR TITLE
CHAT-298: Wrong link of attached file in email's content

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -288,6 +288,8 @@ ChatRoom.prototype.showAsText = function(callback) {
 };
 
 ChatRoom.prototype.sendMeetingNotes = function(room, fromTimestamp, toTimestamp, callback) {
+  var serverBase = window.location.href.substr(0, 9+window.location.href.substr(9).indexOf("/"));
+  
   var thiss = this;
   snack.request({
     url: thiss.jzChatSendMeetingNotes,
@@ -295,6 +297,7 @@ ChatRoom.prototype.sendMeetingNotes = function(room, fromTimestamp, toTimestamp,
       room: room,
       user: thiss.username,
       token: thiss.token,
+      serverBase: serverBase,
       fromTimestamp: fromTimestamp,
       toTimestamp: toTimestamp
     }

--- a/server/src/main/java/org/exoplatform/chat/model/ReportBean.java
+++ b/server/src/main/java/org/exoplatform/chat/model/ReportBean.java
@@ -294,7 +294,7 @@ public class ReportBean {
     return xwiki.toString();
   }
 
-  public String getAsHtml(String title)
+  public String getAsHtml(String title, String serverBase)
   {
     StringBuilder html = new StringBuilder();
     html.append("<div style='font-family: Lucida,arial,tahoma;'>");
@@ -384,7 +384,7 @@ public class ReportBean {
     for (FileBean file:this.getFiles())
     {
       html.append("<div style='padding: 4px'>");
-      html.append("  <div><a href='http://demo.exoplatform.net"+file.getUrl().replaceFirst("/rest", "/rest/private")+"'>").append(file.getName()).append("</a></div>");
+      html.append("  <div><a href='"+serverBase+""+file.getUrl().replaceFirst("/rest", "/rest/private")+"'>").append(file.getName()).append("</a></div>");
       html.append("  <div style='color: #ccc;'>").append(file.getSize()).append("</div>");
       html.append("</div>");
     }

--- a/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -238,7 +238,7 @@ public class ChatServer
   @Resource
   @Route("/sendMeetingNotes")
   public Response.Content sendMeetingNotes(String user, String token, String room, String fromTimestamp,
-                                           String toTimestamp) throws IOException {
+                                           String toTimestamp, String serverBase) throws IOException {
     if (!tokenService.hasUserWithToken(user,  token))
     {
       return Response.notFound("Petit malin !");
@@ -310,7 +310,7 @@ public class ChatServer
           sender += "<" + userBean.getEmail() + ">";
         }
       }
-      html = reportBean.getAsHtml(title);
+      html = reportBean.getAsHtml(title, serverBase);
       
       try {
         sendMailWithAuth(sender, tos, html.toString(), title);


### PR DESCRIPTION
Fix description: Remove the hardcode & replace by the current domain name.
