### PR TITLE
Optimizations/roomrefreshing

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -412,11 +412,13 @@ ChatRoom.prototype.showMessages = function(msgs, merge) {
 	    messages({date:"pending"}).remove();
 	    
 	    for (var m in msgs.messages) {
+	    	if( msgs.messages.hasOwnProperty( m ) ) {
 	    	var r = messages({id:msgs.messages[m].id});
 	    	if(r.count()>0) {
 	    		r.update(msgs.messages[m]);
 	    	} else {
 	    		messages.insert(msgs.messages[m]);
+	    	}
 	    	}
 	    }
   		

--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -1,4 +1,4 @@
-
+﻿
 /**
  ##################                           ##################
  ##################                           ##################
@@ -14,7 +14,7 @@
  */
 function ChatRoom(jzChatRead, jzChatSend, jzChatGetRoom, jzChatUpdateUnreadMessages, jzChatSendMeetingNotes, jzChatGetMeetingNotes, chatIntervalChat, isPublic, dbName) {
   this.id = "";
-  this.messages = "";
+  this.messages = [];
   this.jzChatRead = jzChatRead;
   this.jzChatSend = jzChatSend;
   this.jzChatGetRoom = jzChatGetRoom;
@@ -72,16 +72,24 @@ ChatRoom.prototype.init = function(username, token, targetUser, targetFullname, 
       jzStoreParam("lastUsername"+thiss.username, thiss.targetUser, 60000);
       jzStoreParam("lastFullName"+thiss.username, thiss.targetFullname, 60000);
       jzStoreParam("lastTS"+thiss.username, "0");
-      thiss.chatEventInt = window.clearInterval(thiss.chatEventInt);
-      thiss.chatEventInt = setInterval(jqchat.proxy(thiss.refreshChat, thiss), thiss.chatIntervalChat);
-      thiss.refreshChat(true, function() {
-        // always scroll to the last message when loading a chat room
-        var $chats = jqchat("#chats");
-        $chats.scrollTop($chats.prop('scrollHeight') - $chats.innerHeight());
-      });
+      
+	  thiss.enableRefresh(true);
+
     }
   });
 
+};
+
+ChatRoom.prototype.enableRefresh = function(isEnabled) {
+  this.chatEventInt = window.clearInterval(this.chatEventInt);
+  if(isEnabled) {
+      this.chatEventInt = setInterval(jqchat.proxy(this.refreshChat, this), this.chatIntervalChat);
+      this.refreshChat(true, function() {
+	    // always scroll to the last message when loading a chat room
+    	var $chats = jqchat("#chats");
+    	$chats.scrollTop($chats.prop('scrollHeight') - $chats.innerHeight());
+  	});
+  }
 };
 
 ChatRoom.prototype.onRefresh = function(callback) {
@@ -192,6 +200,9 @@ ChatRoom.prototype.refreshChat = function(forceRefresh, callback) {
   //var thiss = chatApplication;
   if (this.username !== this.ANONIM_USER) {
     var lastTS = jzGetParam("lastTS"+this.username);
+    var lastUpdatedTS = jzGetParam("lastUpdatedTS"+this.username);
+
+    var fromTimestamp = lastTS == 0 ? lastTS : Math.max(lastTS, lastUpdatedTS);
 
     var thiss = this;
     snack.request({
@@ -200,6 +211,7 @@ ChatRoom.prototype.refreshChat = function(forceRefresh, callback) {
         room: this.id,
         user: this.username,
         token: this.token,
+        fromTimestamp: fromTimestamp,
         dbName: this.dbName
       }
     }, function (err, res){
@@ -249,7 +261,7 @@ ChatRoom.prototype.refreshChat = function(forceRefresh, callback) {
 //      console.log("chatEvent :: lastTS="+lastTS+" :: serverTS="+data.timestamp);
       var im, message, out="", prevUser="";
       if (data.messages.length===0) {
-        thiss.showMessages(data);
+        thiss.showMessages(data, lastTS != 0);
       } else {
         var ts = data.timestamp;
         var updatedTS = Math.max.apply(Math,TAFFY(data.messages)().select("lastUpdatedTimestamp").filter(Boolean));
@@ -259,7 +271,7 @@ ChatRoom.prototype.refreshChat = function(forceRefresh, callback) {
           jzStoreParam("lastUpdatedTS"+thiss.username, updatedTS, 600);
 
           //console.log("new data to show");
-          thiss.showMessages(data);
+          thiss.showMessages(data, lastTS != 0);
         }
       }
 
@@ -389,11 +401,29 @@ ChatRoom.prototype.getUserLastMessage = function() {
 /**
  * Show Messages (json to html)
  * @param msgs : json messages data to show
+ * @param merge : if true merge msgs with the current list, else replace
  */
-ChatRoom.prototype.showMessages = function(msgs) {
+ChatRoom.prototype.showMessages = function(msgs, merge) {
   var im, message, out="", prevUser="", prevFullName, prevOptions, msRightInfo ="", msUserMes="";
   if (msgs!==undefined) {
-    this.messages = msgs.messages;
+  	if(merge) {
+	    var messages = TAFFY(this.messages);
+	    
+	    messages({date:"pending"}).remove();
+	    
+	    for (var m in msgs.messages) {
+	    	var r = messages({id:msgs.messages[m].id});
+	    	if(r.count()>0) {
+	    		r.update(msgs.messages[m]);
+	    	} else {
+	    		messages.insert(msgs.messages[m]);
+	    	}
+	    }
+  		
+  		this.messages = messages().get();
+  	} 	else {
+    	this.messages = msgs.messages;
+  	}
   }
 
   if (this.messages.length===0) {

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -1552,14 +1552,36 @@ ChatApplication.prototype.initChat = function() {
 
   this.initChatPreferences();
 
-  this.chatOnlineInt = clearInterval(this.chatOnlineInt);
-  this.chatOnlineInt = setInterval(jqchat.proxy(this.refreshWhoIsOnline, this), this.chatIntervalUsers);
-  this.refreshWhoIsOnline();
+  this.enableRefresh(true);
+
+  var thiss = this;
+  document.addEventListener("visibilitychange", function() {
+    if (document.hidden) {
+      console.log("disabling refresh");
+      //TODO it could be interesting to regroup whoisonline and notification services
+      //thiss.enableRefresh(false);
+      thiss.chatRoom.enableRefresh(false);
+      //chatNotification.enableNotifRefresh(false);
+      chatNotification.enableStatusRefresh(false);
+    } else {
+      console.log("enabling refresh");
+      //thiss.enableRefresh(true);
+      thiss.chatRoom.enableRefresh(true);
+      //chatNotification.enableNotifRefresh(true);
+      chatNotification.enableStatusRefresh(true);
+    }
+  }, false);
 
   if (this.username!==this.ANONIM_USER) setTimeout(jqchat.proxy(this.showSyncPanel, this), 1000);
 };
 
-
+ChatApplication.prototype.enableRefresh = function(isEnabled) {
+  this.chatOnlineInt = clearInterval(this.chatOnlineInt);
+  if (isEnabled) {
+    this.chatOnlineInt = setInterval(jqchat.proxy(this.refreshWhoIsOnline, this), this.chatIntervalUsers);
+    this.refreshWhoIsOnline();
+  }
+}
 
 /**
  * Init Chat Preferences

--- a/application/src/main/webapp/js/notif.js
+++ b/application/src/main/webapp/js/notif.js
@@ -89,7 +89,7 @@ ChatNotification.prototype.updateNotifEventURL = function() {
  * @param callback : allows you to call an async callback function(username, fullname) when the profile is initiated.
  */
 ChatNotification.prototype.initUserProfile = function(callback) {
-
+  var thiss = this;
   jqchat.ajax({
     url: this.jzInitUserProfile,
     dataType: "json",
@@ -105,13 +105,9 @@ ChatNotification.prototype.initUserProfile = function(callback) {
         callback(this.username, fullname);
       }
 
-      this.notifEventInt = window.clearInterval(this.notifEventInt);
-      this.notifEventInt = setInterval(jqchat.proxy(this.refreshNotif, this), this.chatIntervalNotif);
-      this.refreshNotif();
+      thiss.enableNotifRefresh(true);
+      thiss.enableStatusRefresh(true);
 
-      this.statusEventInt = window.clearInterval(this.statusEventInt);
-      this.statusEventInt = setInterval(jqchat.proxy(this.refreshStatusChat, this), this.chatIntervalStatus);
-      this.refreshStatusChat();
     },
     error: function () {
       //retry in 3 sec
@@ -121,6 +117,21 @@ ChatNotification.prototype.initUserProfile = function(callback) {
 
 };
 
+ChatNotification.prototype.enableNotifRefresh = function(isEnabled) {
+  this.notifEventInt = window.clearInterval(this.notifEventInt);
+  if (isEnabled) {
+    this.notifEventInt = setInterval(jqchat.proxy(this.refreshNotif, this), this.chatIntervalNotif);
+    this.refreshNotif();
+  }
+}
+
+ChatNotification.prototype.enableStatusRefresh = function(isEnabled) {
+  this.statusEventInt = window.clearInterval(this.statusEventInt);
+  if (isEnabled) {
+      this.statusEventInt = setInterval(jqchat.proxy(this.refreshStatusChat, this), this.chatIntervalStatus);
+      this.refreshStatusChat();
+  }
+}
 
 /**
  * Refresh Notifications

--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
@@ -19,13 +19,20 @@
 
 package org.exoplatform.chat.services.mongodb;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import com.mongodb.MongoException;
-import com.mongodb.WriteConcern;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
@@ -41,18 +48,13 @@ import org.exoplatform.chat.services.UserService;
 import org.exoplatform.chat.utils.ChatUtils;
 import org.exoplatform.chat.utils.PropertyManager;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
-import javax.inject.Inject;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+import com.mongodb.WriteConcern;
 
 @Named("chatService")
 @ApplicationScoped
@@ -259,7 +261,9 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
     {
       tsobj.append("$lt", toTimestamp);
     }
-    query.put("timestamp", tsobj);
+    BasicDBObject ts = new BasicDBObject("timestamp",tsobj);
+    BasicDBObject updts = new BasicDBObject("lastUpdatedTimestamp",tsobj);
+    query.put("$or", new BasicDBObject[]{ts, updts});
 
     BasicDBObject sort = new BasicDBObject();
     sort.put("timestamp", -1);


### PR DESCRIPTION
Hello, here are some optimizations of chat room refresh. 

1) Diff room refresh : 
Instead of refreshing all the messages of a room, get the last updates and merge with the message list.
It relies on the read service param "fromTimestamp" that was not used until now. But I had to modify the query in order to return messages containing "lastUpdatedTimestamp" field that was greater than timestamp.
Response of the read service is merged with the messages of the room (edited and removed messages are updated, new messages are added, pending are removed)

As a consequence of this server resource saving, you could extend the message limit of the room (defaults to 200) :)

2) Disabling polling when page is not visible
It does make sense with status and read requests. But we have to keep polling on whoisonline and notification service in order to notify the user (see below for possible improvement)

limits and further improvements : 
- it uses standard API with no vendor specific attribute detection (could be done) 
- ALT-TAB or window minification is not detected. Also could be done with a little more code, see this link for more detail : https://stereologics.com/2015/04/02/about-page-visibility-api-hidden-visibilitychange-visibilitystate/
- notification polling main purpose is... to play a sound when new notifs come in. 
  In fact Notification updates are  done with Whoisonline polling. It could be interesting (and simple) to merge the notif polling with whoisonline 
