### PR TITLE
CHAT-401 retrieve only new messages when fetching room's data

### DIFF
--- a/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
+++ b/server/src/main/java/org/exoplatform/chat/services/mongodb/ChatServiceImpl.java
@@ -19,13 +19,20 @@
 
 package org.exoplatform.chat.services.mongodb;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import com.mongodb.MongoException;
-import com.mongodb.WriteConcern;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
@@ -41,18 +48,13 @@ import org.exoplatform.chat.services.UserService;
 import org.exoplatform.chat.utils.ChatUtils;
 import org.exoplatform.chat.utils.PropertyManager;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
-import javax.inject.Inject;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+import com.mongodb.WriteConcern;
 
 @Named("chatService")
 @ApplicationScoped
@@ -259,7 +261,9 @@ public class ChatServiceImpl implements org.exoplatform.chat.services.ChatServic
     {
       tsobj.append("$lt", toTimestamp);
     }
-    query.put("timestamp", tsobj);
+    BasicDBObject ts = new BasicDBObject("timestamp",tsobj);
+    BasicDBObject updts = new BasicDBObject("lastUpdatedTimestamp",tsobj);
+    query.put("$or", new BasicDBObject[]{ts, updts});
 
     BasicDBObject sort = new BasicDBObject();
     sort.put("timestamp", -1);


### PR DESCRIPTION
Instead of fetching all room's messages from server (which occurs at periodic rate or after sending a  message), this code retrieve the last modifications and merge them with the room's message list.

It mainly relies on the read service parameter "fromTimestamp" that was not used. But I had to modify the query in order to return messages whose "lastUpdatedTimestamp" field is greater than timestamp (for updated and deleted messages).

Response of the read service is merged with the messages of the room : edited and removed messages are updated accoding to their id, new messages are added, and pending are removed. (I assumed that if there's no message in response that replaces the pending one, then the server didn't receive it, and so we can't lie ! a retry should be better in that case)

As a consequence of this server resource saving, you could extend the message limit of the room (defaults to 200), maybe much higher in order to get all the history (if there's a need to get all history of ig team rooms maybe pagination would be better)
