### PR TITLE
CHAT-402 disable polling when page is not visible

### DIFF
--- a/application/src/main/webapp/js/chat-modules.js
+++ b/application/src/main/webapp/js/chat-modules.js
@@ -72,17 +72,26 @@ ChatRoom.prototype.init = function(username, token, targetUser, targetFullname, 
       jzStoreParam("lastUsername"+thiss.username, thiss.targetUser, 60000);
       jzStoreParam("lastFullName"+thiss.username, thiss.targetFullname, 60000);
       jzStoreParam("lastTS"+thiss.username, "0");
-      thiss.chatEventInt = window.clearInterval(thiss.chatEventInt);
-      thiss.chatEventInt = setInterval(jqchat.proxy(thiss.refreshChat, thiss), thiss.chatIntervalChat);
-      thiss.refreshChat(true, function() {
-        // always scroll to the last message when loading a chat room
-        var $chats = jqchat("#chats");
-        $chats.scrollTop($chats.prop('scrollHeight') - $chats.innerHeight());
-      });
+
+      thiss.enableRefresh(true);
     }
   });
 
 };
+
+ChatRoom.prototype.enableRefresh = function(isEnabled) {
+  this.chatEventInt = window.clearInterval(this.chatEventInt);
+  if (isEnabled) {
+    this.chatEventInt = setInterval(jqchat.proxy(this.refreshChat, this),
+        this.chatIntervalChat);
+    this.refreshChat(true, function() {
+      // always scroll to the last message when loading a chat room
+      var $chats = jqchat("#chats");
+      $chats.scrollTop($chats.prop('scrollHeight') - $chats.innerHeight());
+    });
+  }
+};
+
 
 ChatRoom.prototype.onRefresh = function(callback) {
   this.onRefreshCB = callback;

--- a/application/src/main/webapp/js/chat.js
+++ b/application/src/main/webapp/js/chat.js
@@ -612,7 +612,7 @@ var chatApplication = new ChatApplication();
           console.log("error");
           setActionButtonEnabled('.create-task-button', true);
         }
-      });	
+      });   
     });
 
     $('#task-add-user').keyup(function(event) {
@@ -1552,14 +1552,36 @@ ChatApplication.prototype.initChat = function() {
 
   this.initChatPreferences();
 
-  this.chatOnlineInt = clearInterval(this.chatOnlineInt);
-  this.chatOnlineInt = setInterval(jqchat.proxy(this.refreshWhoIsOnline, this), this.chatIntervalUsers);
-  this.refreshWhoIsOnline();
+  this.enableRefresh(true);
+
+  var thiss = this;
+  document.addEventListener("visibilitychange", function() {
+    if (document.hidden) {
+      console.log("disabling refresh");
+      //TODO it could be interesting to regroup whoisonline and notification services
+      //thiss.enableRefresh(false);
+      thiss.chatRoom.enableRefresh(false);
+      //chatNotification.enableNotifRefresh(false);
+      chatNotification.enableStatusRefresh(false);
+    } else {
+      console.log("enabling refresh");
+      //thiss.enableRefresh(true);
+      thiss.chatRoom.enableRefresh(true);
+      //chatNotification.enableNotifRefresh(true);
+      chatNotification.enableStatusRefresh(true);
+    }
+  }, false);
 
   if (this.username!==this.ANONIM_USER) setTimeout(jqchat.proxy(this.showSyncPanel, this), 1000);
 };
 
-
+ChatApplication.prototype.enableRefresh = function(isEnabled) {
+  this.chatOnlineInt = clearInterval(this.chatOnlineInt);
+  if (isEnabled) {
+    this.chatOnlineInt = setInterval(jqchat.proxy(this.refreshWhoIsOnline, this), this.chatIntervalUsers);
+    this.refreshWhoIsOnline();
+  }
+}
 
 /**
  * Init Chat Preferences

--- a/application/src/main/webapp/js/notif.js
+++ b/application/src/main/webapp/js/notif.js
@@ -89,7 +89,7 @@ ChatNotification.prototype.updateNotifEventURL = function() {
  * @param callback : allows you to call an async callback function(username, fullname) when the profile is initiated.
  */
 ChatNotification.prototype.initUserProfile = function(callback) {
-
+  var thiss = this;
   jqchat.ajax({
     url: this.jzInitUserProfile,
     dataType: "json",
@@ -105,13 +105,9 @@ ChatNotification.prototype.initUserProfile = function(callback) {
         callback(this.username, fullname);
       }
 
-      this.notifEventInt = window.clearInterval(this.notifEventInt);
-      this.notifEventInt = setInterval(jqchat.proxy(this.refreshNotif, this), this.chatIntervalNotif);
-      this.refreshNotif();
+      thiss.enableNotifRefresh(true);
+      thiss.enableStatusRefresh(true);
 
-      this.statusEventInt = window.clearInterval(this.statusEventInt);
-      this.statusEventInt = setInterval(jqchat.proxy(this.refreshStatusChat, this), this.chatIntervalStatus);
-      this.refreshStatusChat();
     },
     error: function () {
       //retry in 3 sec
@@ -121,6 +117,21 @@ ChatNotification.prototype.initUserProfile = function(callback) {
 
 };
 
+ChatNotification.prototype.enableNotifRefresh = function(isEnabled) {
+  this.notifEventInt = window.clearInterval(this.notifEventInt);
+  if (isEnabled) {
+    this.notifEventInt = setInterval(jqchat.proxy(this.refreshNotif, this), this.chatIntervalNotif);
+    this.refreshNotif();
+  }
+}
+
+ChatNotification.prototype.enableStatusRefresh = function(isEnabled) {
+  this.statusEventInt = window.clearInterval(this.statusEventInt);
+  if (isEnabled) {
+      this.statusEventInt = setInterval(jqchat.proxy(this.refreshStatusChat, this), this.chatIntervalStatus);
+      this.refreshStatusChat();
+  }
+}
 
 /**
  * Refresh Notifications
@@ -794,4 +805,3 @@ var chatNotification = new ChatNotification();
 
 var offX;
 var offY;
-


### PR DESCRIPTION
It does make sense with status and read requests. But we have to keep polling on whoisonline and notification service in order to notify the user (see below for possible improvement)

limits and further improvements :
- it uses standard API with no vendor specific attribute detection (could be done)
- ALT-TAB or window minification is not detected. Also could be done with a little more code, see this link for more detail : https://stereologics.com/2015/04/02/about-page-visibility-api-hidden-visibilitychange-visibilitystate/
- notification polling main purpose is... to play a sound when new notifs come in. 
  In fact Notification updates are done with Whoisonline polling. It could be interesting (and simple) to merge the notif polling with whoisonline
