### PR TITLE
Fix for User status Icon not colored on Light Background navbar

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/portlet/notification/assets/sprites.less
+++ b/application/src/main/java/org/exoplatform/chat/portlet/notification/assets/sprites.less
@@ -32,9 +32,6 @@
 }
 
 .UIToolbarContainerLight {
-	.uiNotifChatIcon {
-	  color: @iconStatusDefaultContainerLight;
-	}
 	.toggle-status-invisible {
       color: @iconStatusInvisibleContainerLight;
     }


### PR DESCRIPTION
Tested on 1.2.0 version of the addon.
