### PR TITLE
CHAT-944 Number mongodb's queries increases after the new chat ui dep…

### DIFF
--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -16,14 +16,14 @@ export function getUserStatus(userSettings, user) {
     }}).then(resp =>  resp.text());
 }
 
-export function getNotReadMessages(userSettings) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}notification?user=${userSettings.username}&dbName=${userSettings.dbName}&withDetails=true`, {
+export function getNotReadMessages(userSettings, withDetails) {
+  return fetch(`${chatConstants.CHAT_SERVER_API}notification?user=${userSettings.username}&dbName=${userSettings.dbName}&withDetails=${withDetails}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
 
-export function initChatSettings(username, userSettingsLoadedCallback, chatRoomsLoadedCallback) {
+export function initChatSettings(username, isMiniChat, userSettingsLoadedCallback, chatRoomsLoadedCallback) {
   if (!eXo) { eXo = {}; }
   if (!eXo.chat) { eXo.chat = {}; }
   if (!eXo.chat.userSettings) { eXo.chat.userSettings = {}; }
@@ -31,8 +31,13 @@ export function initChatSettings(username, userSettingsLoadedCallback, chatRooms
 
   document.addEventListener(chatConstants.EVENT_USER_SETTINGS_LOADED, (e) => {
     const settings = e.detail;
-    // fetch online users then fetch chat rooms
-    getOnlineUsers().then(users => getChatRooms(settings, users)).then(data => chatRoomsLoadedCallback(data));
+    if (isMiniChat) {
+      //mini chat only need fetching notifications
+      getNotReadMessages(settings).then(notifications => chatRoomsLoadedCallback(notifications));
+    } else {
+      // fetch online users then fetch chat rooms
+      getOnlineUsers().then(users => getChatRooms(settings, users)).then(data => chatRoomsLoadedCallback(data));
+    }
 
     document.addEventListener(chatConstants.EVENT_ROOM_SELECTION_CHANGED, (e) => {
       const selectedContact = e.detail;

--- a/application/src/main/webapp/vue-app/components/ExoMiniChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoMiniChatApp.vue
@@ -51,10 +51,10 @@ export default {
     }
   },
   created() {
-    chatServices.initChatSettings(this.userSettings.username,
+    chatServices.initChatSettings(this.userSettings.username, true,
       userSettings => this.initSettings(userSettings),
       data => {
-        const totalUnreadMsg = Math.abs(data.unreadOffline) + Math.abs(data.unreadOnline) + Math.abs(data.unreadSpaces) + Math.abs(data.unreadTeams);
+        const totalUnreadMsg = Math.abs(data.total);
         if(totalUnreadMsg >= 0) {
           this.totalUnreadMsg = totalUnreadMsg;
         }

--- a/application/src/main/webapp/vue-app/components/ExoMiniChatNotifList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoMiniChatNotifList.vue
@@ -110,7 +110,7 @@ export default {
     refreshMessages() {
       this.messagesList = [];
       this.isRetrievingMessagges = true;
-      chatServices.getNotReadMessages(eXo.chat.userSettings).then(messages => {
+      chatServices.getNotReadMessages(eXo.chat.userSettings, true).then(messages => {
         this.messagesList = messages && messages.notifications ? messages.notifications : [];
         this.isRetrievingMessagges = false;
       }).catch(() => {
@@ -119,7 +119,7 @@ export default {
     },
     messageReceived() {
       if($('#chatApplicationNotification .status-dropdown').hasClass('open')) {
-        chatServices.getNotReadMessages(eXo.chat.userSettings).then(messages => {
+        chatServices.getNotReadMessages(eXo.chat.userSettings, true).then(messages => {
           this.messagesList = messages && messages.notifications ? messages.notifications : [];
         });
       }


### PR DESCRIPTION
- issue: mini chat app use same init setting method with normal chat app, which fetch more data from mongodb than required. Mini chat app only need total number of unread messages

- fix: add parameter to init setting method to distinguish mini chat app, and fetch only total Unread messages