### PR TITLE
CHAT-848 : create user in chat when he/she is created

### DIFF
--- a/application/src/main/java/org/exoplatform/chat/listener/UpdateUserEventListener.java
+++ b/application/src/main/java/org/exoplatform/chat/listener/UpdateUserEventListener.java
@@ -12,13 +12,12 @@ public class UpdateUserEventListener extends UserEventListener {
   private static final Logger LOG = Logger.getLogger(UpdateUserEventListener.class.getName());
 
   public void postSave(User user, boolean isNew) throws Exception {
+    if (ConversationState.getCurrent() == null) {
+      return;
+    }
     try {
       String dbName = ChatUtils.getDBName();
-      String currentUserId = ConversationState.getCurrent().getIdentity().getUserId();
-      if (!isNew && user.getUserName().equals(currentUserId)) {
-        String fullName = user.getFirstName().concat(" ").concat(user.getLastName());
-        ServerBootstrap.addUserFullNameAndEmail(currentUserId, fullName, user.getEmail(), dbName);
-      }
+      ServerBootstrap.addUserFullNameAndEmail(user.getUserName(), user.getDisplayName(), user.getEmail(), dbName);
     } catch (Exception e) {
       LOG.warning("Can not update firstName/lastName to chatServer");
     }


### PR DESCRIPTION
When an user is created in the platform, he/she is not created in the chat application. It is only done when he/she accesses to the chat for the first time.
Therefore, when trying to chat with an user who never accessed to the chat, there is no data related to this user in the mongo database and it returns null (the value displayed).

To fix this issue, the UpdateUserStatusListener has been updated. It previously only updated the information of existing users when they changed their information.
Now it also process new user : if the user does not exist, it creates it.
This is the same logic that is used in the latest chat version (2.1.0).