### PR TITLE
CHAT-1005 : Can't Upload files on Chat

### DIFF
--- a/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
+++ b/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
@@ -236,7 +236,7 @@ public class DocumentService implements ResourceContainer {
     try {
       Node homeNode;
       if (isPrivateContext) {
-        Node userNode = nodeHierarchyCreator_.getUserNode(sessionProvider, remoteUser);
+        Node userNode = nodeHierarchyCreator_.getUserNode(sessionProviderService_.getSystemSessionProvider(null), remoteUser);
         homeNode = userNode.getNode("Private");
       } else {
         ManageableRepository currentRepository = repositoryService_.getCurrentRepository();


### PR DESCRIPTION
When we use a basic user, we can not upload files on Chat.
This problem is due to access permissions. The user does not have the permission to read the root User Node. 
The solution is to use the System Session instead of User Session when we retrieve the User Node