### PR TITLE
CHAT-363 : remove dbName parameters in all services and REST endpoints

### DIFF
--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -10,7 +10,7 @@ const DEFAULT_HTTP_PORT = 80;
 const REATTEMPT_INIT_PERIOD = 1000;
 
 export function getUserStatus(userSettings, user) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}getStatus?user=${userSettings.username}&targetUser=${user}&dbName=${userSettings.dbName}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}getStatus?user=${userSettings.username}&targetUser=${user}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.text());
@@ -34,7 +34,7 @@ export function setUserStatus(userSettings, status, callback) {
 }
 
 export function getNotReadMessages(userSettings, withDetails) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}notification?user=${userSettings.username}&dbName=${userSettings.dbName}&withDetails=${withDetails}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}notification?user=${userSettings.username}&withDetails=${withDetails}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
@@ -124,13 +124,13 @@ export function toggleFavorite(room, user, favorite) {
   if ((!room || !room.trim().length) && user && user.trim().length) {
     return getRoomId(eXo.chat.userSettings, user, 'username').then((roomId) => {
       room = roomId;
-      return fetch(`${chatConstants.CHAT_SERVER_API}toggleFavorite?user=${eXo.chat.userSettings.username}&targetUser=${room}&favorite=${favorite}&dbName=${eXo.chat.userSettings.dbName}`, {
+      return fetch(`${chatConstants.CHAT_SERVER_API}toggleFavorite?user=${eXo.chat.userSettings.username}&targetUser=${room}&favorite=${favorite}`, {
         headers: {
           'Authorization': `Bearer ${eXo.chat.userSettings.token}`
         }}).then(resp =>  resp.text());
     });
   } else {
-    return fetch(`${chatConstants.CHAT_SERVER_API}toggleFavorite?user=${eXo.chat.userSettings.username}&targetUser=${room}&favorite=${favorite}&dbName=${eXo.chat.userSettings.dbName}`, {
+    return fetch(`${chatConstants.CHAT_SERVER_API}toggleFavorite?user=${eXo.chat.userSettings.username}&targetUser=${room}&favorite=${favorite}`, {
       headers: {
         'Authorization': `Bearer ${eXo.chat.userSettings.token}`
       }}).then(resp =>  resp.text());
@@ -144,28 +144,28 @@ export function getChatRooms(userSettings, onlineUsers, filter, limit) {
   if(!filter) {
     filter = '';
   }
-  return fetch(`${chatConstants.CHAT_SERVER_API}whoIsOnline?user=${userSettings.username}&onlineUsers=${onlineUsers}&dbName=${userSettings.dbName}&filter=${filter}&limit=${limit}&timestamp=${new Date().getTime()}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}whoIsOnline?user=${userSettings.username}&onlineUsers=${onlineUsers}&filter=${filter}&limit=${limit}&timestamp=${new Date().getTime()}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
 
 export function getRoomParticipants(userSettings, room) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}users?user=${userSettings.username}&dbName=${userSettings.dbName}&room=${room.room}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}users?user=${userSettings.username}&room=${room.room}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
 
 export function getRoomId(userSettings, targetUser, fieldName) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}getRoom?targetUser=${targetUser}&user=${userSettings.username}&dbName=${userSettings.dbName}&type=${fieldName}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}getRoom?targetUser=${targetUser}&user=${userSettings.username}&type=${fieldName}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.text());
 }
 
 export function getRoomDetail(userSettings, room) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}getRoom?targetUser=${room}&user=${userSettings.username}&dbName=${userSettings.dbName}&withDetail=true&type=room-id`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}getRoom?targetUser=${room}&user=${userSettings.username}&withDetail=true&type=room-id`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
@@ -178,14 +178,14 @@ export function getRoomMessages(userSettings, contact, toTimestamp, limit) {
   if(!toTimestamp) {
     toTimestamp = '';
   }
-  return fetch(`${chatConstants.CHAT_SERVER_API}read?user=${userSettings.username}&dbName=${userSettings.dbName}&room=${contact.room}&toTimestamp=${toTimestamp}&limit=${limit}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}read?user=${userSettings.username}&room=${contact.room}&toTimestamp=${toTimestamp}&limit=${limit}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
 
 export function setRoomNotificationTrigger(userSettings, room, notifConditionType, notifCondition, time) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}setRoomNotificationTrigger?user=${userSettings.username}&dbName=${userSettings.dbName}&room=${room}&notifConditionType=${notifConditionType}&notifCondition=${notifCondition}&time=${time}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}setRoomNotificationTrigger?user=${userSettings.username}&room=${room}&notifConditionType=${notifConditionType}&notifCondition=${notifCondition}&time=${time}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
@@ -200,21 +200,21 @@ export function setUserNotificationPreferences(userSettings, preferredNotificati
   preferredNotificationTriggers.forEach(preferredNotificationTrigger => {
     preferredNotificationTriggerParam += `&notifManners=${preferredNotificationTrigger}`;
   });
-  return fetch(`${chatConstants.CHAT_SERVER_API}setNotificationSettings?user=${userSettings.username}&dbName=${userSettings.dbName}${preferredNotificationParam}${preferredNotificationTriggerParam}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}setNotificationSettings?user=${userSettings.username}${preferredNotificationParam}${preferredNotificationTriggerParam}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
 
 export function setUserPreferredNotification(userSettings, notifManner) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}setPreferredNotification?user=${userSettings.username}&dbName=${userSettings.dbName}&notifManner=${notifManner}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}setPreferredNotification?user=${userSettings.username}&notifManner=${notifManner}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
 
 export function getUserNotificationSettings(userSettings) {
-  return fetch(`${chatConstants.CHAT_SERVER_API}getUserDesktopNotificationSettings?user=${userSettings.username}&dbName=${userSettings.dbName}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}getUserDesktopNotificationSettings?user=${userSettings.username}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
@@ -245,7 +245,7 @@ export function getChatUsers(userSettings, filter, limit) {
   if(!limit) {
     limit = DEFAULT_USER_LIMIT;
   }
-  return fetch(`${chatConstants.CHAT_SERVER_API}users?user=${userSettings.username}&dbName=${userSettings.dbName}&filter=${filter}&limit=${limit}`, {
+  return fetch(`${chatConstants.CHAT_SERVER_API}users?user=${userSettings.username}&filter=${filter}&limit=${limit}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
@@ -256,7 +256,6 @@ export function saveRoom(userSettings, roomName, users, room) {
     teamName: roomName,
     users: users,
     user: userSettings.username,
-    dbName: userSettings.dbName,
     room: room
   };
 
@@ -296,7 +295,6 @@ export function sendMeetingNotes(userSettings, room, fromTimestamp, toTimestamp)
 
   const data = {
     user: userSettings.username,
-    dbName: userSettings.dbName,
     room: room,
     serverBase: serverBase,
     fromTimestamp: fromTimestamp,
@@ -317,7 +315,6 @@ export function getMeetingNotes(userSettings, room, fromTimestamp, toTimestamp) 
   const serverBase = getBaseURL();
   const data = {
     user: userSettings.username,
-    dbName: userSettings.dbName,
     room: room,
     portalURI: `${eXo.env.portal.context}/${eXo.env.portal.portalName}`,
     serverBase: serverBase,

--- a/application/src/main/webapp/vue-app/chatWebSocket.js
+++ b/application/src/main/webapp/vue-app/chatWebSocket.js
@@ -8,7 +8,6 @@ export function initSettings(settings) {
   cometDSettings.token = settings.token;
   cometDSettings.username = settings.username;
   cometDSettings.sessionId = settings.sessionId;
-  cometDSettings.dbName = settings.dbName;
   cometDSettings.spaceId = settings.spaceId;
   cometDSettings.fullname = settings.fullName;
   cometDSettings.cometdToken = settings.cometdToken;
@@ -100,7 +99,6 @@ export function setStatus(status, callback, errorCallback) {
       'event': 'user-status-changed',
       'sender': cometDSettings.username,
       'room': cometDSettings.username,
-      'dbName': cometDSettings.dbName,
       'token': cometDSettings.token,
       'data': {
         'status': status
@@ -130,7 +128,6 @@ export function leaveRoom(room, callback) {
     'clientId': new Date().getTime().toString(),
     'sender': cometDSettings.username,
     'token': cometDSettings.token,
-    'dbName': cometDSettings.dbName,
     'room': room,
     'options' : {
       'fullName': cometDSettings.fullname
@@ -150,7 +147,6 @@ export function deleteRoom(room, callback) {
     'event': 'room-deleted',
     'sender': cometDSettings.username,
     'token': cometDSettings.token,
-    'dbName': cometDSettings.dbName,
     'room': room
   });
   cometDSettings.cCometD.publish('/service/chat', content, function(publishAck) {
@@ -183,7 +179,6 @@ export function sendMessage(messageObj, callback) {
     'room': messageObj.room,
     'sender': cometDSettings.username,
     'token': cometDSettings.token,
-    'dbName': cometDSettings.dbName,
     'data': data
   };
 
@@ -210,7 +205,6 @@ export function deleteMessage(messageObj, callback) {
     'event': 'message-deleted',
     'sender': cometDSettings.username,
     'token': cometDSettings.token,
-    'dbName': cometDSettings.dbName,
     'room': messageObj.room,
     'data': {
       'msgId': messageObj.msgId
@@ -228,7 +222,6 @@ export function setRoomMessagesAsRead(room, callback) {
   const data = JSON.stringify({
     'event': 'message-read',
     'sender': cometDSettings.username,
-    'dbName': cometDSettings.dbName,
     'token': cometDSettings.token,
     'room': room
   });

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -63,7 +63,6 @@ export default {
       /**
        * chatPage: {String}
        * cometdToken: {String}
-       * dbName: {String}
        * fullName: {String}
        * isOnline: {Boolean}
        * maxUploadSize: {Number}

--- a/application/src/main/webapp/vue-app/extension.js
+++ b/application/src/main/webapp/vue-app/extension.js
@@ -258,7 +258,6 @@ const DEFAULT_COMPOSER_APPS = [
               credentials: 'include',
               body: $.param({
                 uploadId: uploadId,
-                dbName: eXo.chat.userSettings.dbName,
                 token: eXo.chat.userSettings.token,
                 targetRoom: thiss.contact.user,
                 targetFullname: thiss.contact.fullName

--- a/common/src/main/java/org/exoplatform/chat/services/ChatService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/ChatService.java
@@ -52,13 +52,13 @@ public interface ChatService
 
   public static final String USER_AVATAR_URL= "/rest/v1/social/users/{}/avatar";
 
-  public void write(String message, String user, String room, String isSystem, String dbName);
+  public void write(String message, String user, String room, String isSystem);
 
-  public void write(String clientId, String message, String user, String room, String isSystem, String options, String dbName);
+  public void write(String clientId, String message, String user, String room, String isSystem, String options);
 
-  public String save(String message, String user, String room, String isSystem, String options, String dbName);
+  public String save(String message, String user, String room, String isSystem, String options);
 
-  public void delete(String room, String user, String messageId, String dbName);
+  public void delete(String room, String user, String messageId);
 
   /**
    * Delete a Team Room by its corresponding ID.<br>
@@ -71,61 +71,58 @@ public interface ChatService
    *
    * @param roomId the team room ID to delete
    * @param user   the owner of the team room
-   * @param dbName the database to use for the query
    */
-  public void deleteTeamRoom(String roomId, String user, String dbName);
+  public void deleteTeamRoom(String roomId, String user);
 
-  public void edit(String room, String user, String messageId, String message, String dbName);
+  public void edit(String room, String user, String messageId, String message);
 
-  public String read(String user, String room, String dbName);
+  public String read(String user, String room);
 
-  public String read(String user, String room, boolean isTextOnly, Long fromTimestamp, String dbName);
+  public String read(String user, String room, boolean isTextOnly, Long fromTimestamp);
 
-  public String read(String user, String room, boolean isTextOnly, Long fromTimestamp, Long toTimestamp, int limit, String dbName);
+  public String read(String user, String room, boolean isTextOnly, Long fromTimestamp, Long toTimestamp, int limit);
 
-  public MessageBean getMessage(String roomId, String messageId, String dbName);
+  public MessageBean getMessage(String roomId, String messageId);
 
-  public String getSpaceRoom(String space, String dbName);
+  public String getSpaceRoom(String space);
 
-  public String getSpaceRoomByName(String name, String dbName);
+  public String getSpaceRoomByName(String name);
 
-  public String getTeamRoom(String team, String user, String dbName);
+  public String getTeamRoom(String team, String user);
 
-  public String getExternalRoom(String identifier, String dbName);
+  public String getExternalRoom(String identifier);
 
-  public String getTeamCreator(String room, String dbName);
+  public String getTeamCreator(String room);
 
-  public void setRoomName(String room, String name, String dbName);
+  public void setRoomName(String room, String name);
 
   /**
    * Get rooms by name
    * 
    * @param teamName
-   * @param dbName
    * @return
    */
-  public List<RoomBean> getTeamRoomsByName(String teamName, String dbName);
+  public List<RoomBean> getTeamRoomsByName(String teamName);
 
   /**
    * Retrieve a Room by its ID
    * @param roomId the ID of the room
-   * @param dbName the database to use for the query
    * @return the room or null if the room doesn't exists
    */
-  public RoomBean getTeamRoomById(String roomId, String dbName);
+  public RoomBean getTeamRoomById(String roomId);
 
-  public String getRoom(List<String> users, String dbName);
+  public String getRoom(List<String> users);
   
-  public String getTypeRoomChat(String roomId, String dbName);
+  public String getTypeRoomChat(String roomId);
 
-  public List<RoomBean> getExistingRooms(String user, boolean withPublic, boolean isAdmin, NotificationService notificationService, TokenService tokenService, String dbName);
+  public List<RoomBean> getExistingRooms(String user, boolean withPublic, boolean isAdmin, NotificationService notificationService, TokenService tokenService);
 
-  public RoomsBean getRooms(String user, String filter, boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin, NotificationService notificationService, TokenService tokenService, String dbName);
+  public RoomsBean getRooms(String user, String filter, boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin, NotificationService notificationService, TokenService tokenService);
 
-  public RoomsBean getRooms(String user, List<String> onlineUsers, String filter, boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin, int limit, NotificationService notificationService, TokenService tokenService, String dbName);
+  public RoomsBean getRooms(String user, List<String> onlineUsers, String filter, boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin, int limit, NotificationService notificationService, TokenService tokenService);
 
-  public int getNumberOfRooms(String dbName);
+  public int getNumberOfRooms();
 
-  public int getNumberOfMessages(String dbName);
+  public int getNumberOfMessages();
 
 }

--- a/common/src/main/java/org/exoplatform/chat/services/NotificationService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/NotificationService.java
@@ -27,22 +27,22 @@ public interface NotificationService
 {
   public static final String M_NOTIFICATIONS = "notifications";
 
-  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link, String dbName);
+  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link);
 
-  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link, String options, String dbName);
+  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link, String options);
 
-  public void setNotificationsAsRead(String user, String type, String category, String categoryId, String dbName);
+  public void setNotificationsAsRead(String user, String type, String category, String categoryId);
 
-  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String dbName);
+  public List<NotificationBean> getUnreadNotifications(String user, UserService userService);
 
-  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String type, String category, String categoryId, String dbName);
+  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String type, String category, String categoryId);
 
-  public int getUnreadNotificationsTotal(String user, String dbName);
+  public int getUnreadNotificationsTotal(String user);
 
-  public int getUnreadNotificationsTotal(String user, String type, String category, String categoryId, String dbName);
+  public int getUnreadNotificationsTotal(String user, String type, String category, String categoryId);
 
-  public int getNumberOfNotifications(String dbName);
+  public int getNumberOfNotifications();
 
-  public int getNumberOfUnreadNotifications(String dbName);
+  public int getNumberOfUnreadNotifications();
 
 }

--- a/common/src/main/java/org/exoplatform/chat/services/TokenService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/TokenService.java
@@ -32,13 +32,11 @@ public interface TokenService
 
   boolean hasUserWithToken(String user, String token);
 
-  boolean hasUserWithToken(String user, String token, String dbName);
+  void addUser(String user, String token);
 
-  void addUser(String user, String token, String dbName);
+  void removeUserToken(String user, String token);
 
-  void removeUserToken(String user, String token, String dbName);
-
-  Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitUsers, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit);
+  Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitUsers, boolean withUsers, boolean withPublic, boolean isAdmin, int limit);
 
   boolean isDemoUser(String user);
 

--- a/common/src/main/java/org/exoplatform/chat/services/UserService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/UserService.java
@@ -46,70 +46,69 @@ public interface UserService
   public static final String PREFERRED_NOTIFICATION_TRIGGER = "preferredNotificationTrigger";
 
   /**
-   * @deprecated use {@link #addFavorite(String, String, String)} and {@link #removeFavorite(String, String, String)} instead
+   * @deprecated use {@link #addFavorite(String, String)} and {@link #removeFavorite(String, String)} instead
    *
    * @param user
    * @param targetUser
-   * @param dbName
    */
   @Deprecated
-  public void toggleFavorite(String user, String targetUser, String dbName);
+  public void toggleFavorite(String user, String targetUser);
 
-  public void addFavorite(String user, String room, String dbname);
+  public void addFavorite(String user, String room);
 
-  public void removeFavorite(String user, String room, String dbName);
+  public void removeFavorite(String user, String room);
 
-  public void setPreferredNotification(String user, String notifManner, String dbName) throws Exception;
+  public void setPreferredNotification(String user, String notifManner) throws Exception;
 
-  public void setNotificationTrigger(String user, String notifCond, String dbName) throws Exception;
-  public void setRoomNotificationTrigger(String user, String room,String notifCond,String notifConditionType, String dbName, long time) throws Exception;
+  public void setNotificationTrigger(String user, String notifCond) throws Exception;
+  public void setRoomNotificationTrigger(String user, String room,String notifCond,String notifConditionType, long time) throws Exception;
 
-  public NotificationSettingsBean getUserDesktopNotificationSettings(String user, String dbName) throws JSONException;
+  public NotificationSettingsBean getUserDesktopNotificationSettings(String user) throws JSONException;
 
-  public boolean isFavorite(String user, String targetUser, String dbName);
+  public boolean isFavorite(String user, String targetUser);
 
-  public void addUserFullName(String user, String fullname, String dbName);
+  public void addUserFullName(String user, String fullname);
 
-  public void addUserEmail(String user, String email, String dbName);
+  public void addUserEmail(String user, String email);
 
-  public void setSpaces(String user, List<SpaceBean> spaces, String dbName);
+  public void setSpaces(String user, List<SpaceBean> spaces);
 
-  public void addTeamRoom(String user, String teamRoomId, String dbName);
+  public void addTeamRoom(String user, String teamRoomId);
 
-  public void addTeamUsers(String teamRoomId, List<String> users, String dbName);
+  public void addTeamUsers(String teamRoomId, List<String> users);
 
-  public void removeTeamUsers(String teamRoomId, List<String> users, String dbName);
+  public void removeTeamUsers(String teamRoomId, List<String> users);
 
-  public List<RoomBean> getTeams(String user, String dbName);
+  public List<RoomBean> getTeams(String user);
 
-  public RoomBean getRoom(String user, String roomId, String dbName);
+  public RoomBean getRoom(String user, String roomId);
 
-  public List<SpaceBean> getSpaces(String user, String dbName);
+  public List<SpaceBean> getSpaces(String user);
 
-  public List<UserBean> getUsersInRoomChatOneToOne(String roomId, String dbName);
+  public List<UserBean> getUsersInRoomChatOneToOne(String roomId);
 
-  public List<UserBean> getUsers(String roomId, String dbName);
+  public List<UserBean> getUsers(String roomId);
 
-  public List<UserBean> getUsers(String filter, boolean fullBean, String dbName);
+  public List<UserBean> getUsers(String filter, boolean fullBean);
 
-  public List<UserBean> getUsers(String roomId, String filter, int limit, String dbName);
+  public List<UserBean> getUsers(String roomId, String filter, int limit);
 
-  public String setStatus(String user, String status, String dbName);
+  public String setStatus(String user, String status);
 
-  public void setAsAdmin(String user, boolean isAdmin, String dbName);
+  public void setAsAdmin(String user, boolean isAdmin);
 
-  public boolean isAdmin(String user, String dbName);
+  public boolean isAdmin(String user);
 
-  public String getStatus(String user, String dbName);
+  public String getStatus(String user);
 
-  public String getUserFullName(String user, String dbName);
+  public String getUserFullName(String user);
 
-  public UserBean getUser(String user, String dbName);
+  public UserBean getUser(String user);
 
-  public UserBean getUser(String user, boolean withFavorites, String dbName);
+  public UserBean getUser(String user, boolean withFavorites);
 
-  public List<String> getUsersFilterBy(String user, String room, String type, String dbName);
+  public List<String> getUsersFilterBy(String user, String room, String type);
 
-  public int getNumberOfUsers(String dbName);
+  public int getNumberOfUsers();
 
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatTools.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatTools.java
@@ -67,14 +67,14 @@ public class ChatTools
 
   @Resource
   @Route("/addUser")
-  public Response.Content addUser(String username, String token, String passphrase, String dbName)
+  public Response.Content addUser(String username, String token, String passphrase)
   {
     if (!checkPassphrase(passphrase))
     {
       return Response.notFound("{ \"message\": \"passphrase doesn't match\"}");
     }
 
-    tokenService.addUser(username, token, dbName);
+    tokenService.addUser(username, token);
 
     return Response.ok("OK").withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
@@ -82,7 +82,7 @@ public class ChatTools
   @SuppressWarnings("unchecked")
   @Resource
   @Route("/logout")
-  public Response.Content logout(String username, String token, String sessionId, String passphrase, String dbName, String uniqueSession)
+  public Response.Content logout(String username, String token, String sessionId, String passphrase, String uniqueSession)
   {
     if (!checkPassphrase(passphrase)) {
       return Response.notFound("{ \"message\": \"passphrase doesn't match\"}");
@@ -116,30 +116,30 @@ public class ChatTools
 
   @Resource
   @Route("/setAsAdmin")
-  public Response.Content setAsAdmin(String username, String isAdmin, String passphrase, String dbName)
+  public Response.Content setAsAdmin(String username, String isAdmin, String passphrase)
   {
     if (!checkPassphrase(passphrase))
     {
       return Response.notFound("{ \"message\": \"passphrase doesn't match\"}");
     }
 
-    userService.setAsAdmin(username, "true".equals(isAdmin), dbName);
+    userService.setAsAdmin(username, "true".equals(isAdmin));
 
     return Response.ok("OK").withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
   @Route("/addUserFullNameAndEmail")
-  public Response.Content addUserFullNameAndEmail(String username, String fullname, String email, String passphrase, String dbName)
+  public Response.Content addUserFullNameAndEmail(String username, String fullname, String email, String passphrase)
   {
     if (!checkPassphrase(passphrase))
     {
       return Response.notFound("{ \"message\": \"passphrase doesn't match\"}");
     }
     try {
-      userService.addUserEmail(username, email, dbName);
+      userService.addUserEmail(username, email);
       fullname = (String)ChatUtils.fromString(fullname);
-      userService.addUserFullName(username, fullname, dbName);
+      userService.addUserFullName(username, fullname);
     } catch (Exception e) {
       LOG.info("fullname wasn't serialized : " + e.getMessage());
     }
@@ -149,7 +149,7 @@ public class ChatTools
 
   @Resource
   @Route("/setSpaces")
-  public Response.Content setSpaces(String username, String spaces, String passphrase, String dbName)
+  public Response.Content setSpaces(String username, String spaces, String passphrase)
   {
     if (!checkPassphrase(passphrase))
     {
@@ -158,7 +158,7 @@ public class ChatTools
 
     try {
       SpaceBeans spaceBeans = (SpaceBeans)ChatUtils.fromString(spaces);
-      userService.setSpaces(username, spaceBeans.getSpaces(), dbName);
+      userService.setSpaces(username, spaceBeans.getSpaces());
     } catch (IOException e) {
       LOG.warning(e.getMessage());
     } catch (ClassNotFoundException e) {
@@ -170,21 +170,21 @@ public class ChatTools
 
   @Resource
   @Route("/getUserFullName")
-  public Response.Content getUserFullName(String username, String passphrase, String dbName)
+  public Response.Content getUserFullName(String username, String passphrase)
   {
     if (!checkPassphrase(passphrase))
     {
       return Response.notFound("{ \"message\": \"passphrase doesn't match\"}");
     }
 
-    String fullname = userService.getUserFullName(username, dbName);
+    String fullname = userService.getUserFullName(username);
 
     return Response.ok(String.valueOf(fullname)).withMimeType("text/event-stream").withCharset(Tools.UTF_8).withHeader("Cache-Control", "no-cache");
   }
 
   @Resource
   @Route("/updateUnreadTestMessages")
-  public Response.Content updateUnreadTestMessages(String username, String room, String passphrase, String dbName)
+  public Response.Content updateUnreadTestMessages(String username, String room, String passphrase)
   {
     if (!checkPassphrase(passphrase))
     {
@@ -205,9 +205,9 @@ public class ChatTools
       return Response.ok("OK").withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
 
     if (!room.equals("ALL"))
-      notificationService.setNotificationsAsRead(username, "chat", "room", room, dbName);
+      notificationService.setNotificationsAsRead(username, "chat", "room", room);
     else
-      notificationService.setNotificationsAsRead(username, null, null, null, dbName);
+      notificationService.setNotificationsAsRead(username, null, null, null);
 
     return Response.ok("OK").withMimeType("text/event-stream; charset=UTF-8").withHeader("Cache-Control", "no-cache");
   }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatDataStorage.java
@@ -27,13 +27,13 @@ import java.util.List;
 
 public interface ChatDataStorage
 {
-  public void write(String message, String user, String room, String isSystem, String dbName);
+  public void write(String message, String user, String room, String isSystem);
 
-  public void write(String message, String user, String room, String isSystem, String options, String dbName);
+  public void write(String message, String user, String room, String isSystem, String options);
 
-  public String save(String message, String user, String room, String isSystem, String options, String dbName);
+  public String save(String message, String user, String room, String isSystem, String options);
 
-  public void delete(String room, String user, String messageId, String dbName);
+  public void delete(String room, String user, String messageId);
 
   /**
    * Delete a Team Room by its corresponding ID.<br>
@@ -46,54 +46,51 @@ public interface ChatDataStorage
    *
    * @param roomId the team room ID to delete
    * @param user   the owner of the team room
-   * @param dbName the database to use for the query
    */
-  public void deleteTeamRoom(String roomId, String user, String dbName);
+  public void deleteTeamRoom(String roomId, String user);
 
-  public void edit(String room, String user, String messageId, String message, String dbName);
+  public void edit(String room, String user, String messageId, String message);
 
-  public String read(String room, String dbName);
+  public String read(String room);
 
-  public String read(String room, boolean isTextOnly, Long fromTimestamp, String dbName);
+  public String read(String room, boolean isTextOnly, Long fromTimestamp);
 
   /**
-   * Read messages from room from a dedicated timestamp to another usin dbName with limit.
+   * Read messages from room from a dedicated timestamp to another with limit.
    * 
    * @param room
    * @param isTextOnly
    * @param fromTimestamp
    * @param toTimestamp
-   * @param dbName
    * @param limitToLoad
    * @return
    */
-  public String read(String room, boolean isTextOnly, Long fromTimestamp, Long toTimestamp, String dbName, int limitToLoad);
+  public String read(String room, boolean isTextOnly, Long fromTimestamp, Long toTimestamp, int limitToLoad);
 
-  public MessageBean getMessage(String roomId, String messageId, String dbName);
+  public MessageBean getMessage(String roomId, String messageId);
 
-  public String getSpaceRoom(String space, String dbName);
+  public String getSpaceRoom(String space);
 
-  public String getSpaceRoomByName(String name, String dbName);
+  public String getSpaceRoomByName(String name);
 
-  public String getTeamRoom(String team, String user, String dbName);
+  public String getTeamRoom(String team, String user);
 
-  public String getExternalRoom(String identifier, String dbName);
+  public String getExternalRoom(String identifier);
 
-  public String getTeamCreator(String room, String dbName);
+  public String getTeamCreator(String room);
 
-  public void setRoomName(String room, String name, String dbName);
+  public void setRoomName(String room, String name);
 
   /**
    * Retrieve a Room by its ID
    * @param roomId the ID of the room
-   * @param dbName the database to use for the query
    * @return the room or null if the room doesn't exists
    */
-  public RoomBean getTeamRoomById(String roomId, String dbName);
+  public RoomBean getTeamRoomById(String roomId);
 
-  public String getRoom(List<String> users, String dbName);
+  public String getRoom(List<String> users);
   
-  public String getTypeRoomChat(String roomId, String dbName);
+  public String getTypeRoomChat(String roomId);
 
   /**
    * @param user
@@ -101,25 +98,23 @@ public interface ChatDataStorage
    * @param isAdmin
    * @param notificationService
    * @param tokenService
-   * @param dbName
    *
    * @return All existing personal rooms of given <code>user</code>
    */
-  public List<RoomBean> getExistingRooms(String user, boolean withPublic, boolean isAdmin, NotificationService notificationService, TokenService tokenService, String dbName);
+  public List<RoomBean> getExistingRooms(String user, boolean withPublic, boolean isAdmin, NotificationService notificationService, TokenService tokenService);
 
-  public RoomsBean getRooms(String user, List<String> onlineUsers, String filter, boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin, int limit, NotificationService notificationService, TokenService tokenService, String dbName);
+  public RoomsBean getRooms(String user, List<String> onlineUsers, String filter, boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin, int limit, NotificationService notificationService, TokenService tokenService);
 
-  public int getNumberOfRooms(String dbName);
+  public int getNumberOfRooms();
 
-  public int getNumberOfMessages(String dbName);
+  public int getNumberOfMessages();
 
   /**
    * Return rooms by name
    * 
    * @param teamName
-   * @param dbName
    * @return
    */
-  public List<RoomBean> getTeamRoomByName(String teamName, String dbName);
+  public List<RoomBean> getTeamRoomByName(String teamName);
 
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/NotificationDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/NotificationDataStorage.java
@@ -27,22 +27,22 @@ public interface NotificationDataStorage
 {
   public static final String M_NOTIFICATIONS = "notifications";
 
-  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link, String dbName);
+  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link);
 
-  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link, String options, String dbName);
+  public void addNotification(String receiver, String sender, String type, String category, String categoryId, String content, String link, String options);
 
-  public void setNotificationsAsRead(String user, String type, String category, String categoryId, String dbName);
+  public void setNotificationsAsRead(String user, String type, String category, String categoryId);
 
-  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String dbName);
+  public List<NotificationBean> getUnreadNotifications(String user, UserService userService);
 
-  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String type, String category, String categoryId, String dbName);
+  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String type, String category, String categoryId);
 
-  public int getUnreadNotificationsTotal(String user, String dbName);
+  public int getUnreadNotificationsTotal(String user);
 
-  public int getUnreadNotificationsTotal(String user, String type, String category, String categoryId, String dbName);
+  public int getUnreadNotificationsTotal(String user, String type, String category, String categoryId);
 
-  public int getNumberOfNotifications(String dbName);
+  public int getNumberOfNotifications();
 
-  public int getNumberOfUnreadNotifications(String dbName);
+  public int getNumberOfUnreadNotifications();
 
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/NotificationServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/NotificationServiceImpl.java
@@ -47,58 +47,58 @@ public class NotificationServiceImpl implements org.exoplatform.chat.services.No
   private NotificationDataStorage storage;
 
   public void addNotification(String receiver, String sender, String type, String category, String categoryId,
-                              String content, String link, String dbName) {
-    storage.addNotification(receiver, sender, type, category, categoryId, content, link, null, dbName);
+                              String content, String link) {
+    storage.addNotification(receiver, sender, type, category, categoryId, content, link, null);
   }
 
   public void addNotification(String receiver, String sender, String type, String category, String categoryId,
-                              String content, String link, String options, String dbName) {
-    storage.addNotification(receiver, sender, type, category, categoryId, content, link, options, dbName);
+                              String content, String link, String options) {
+    storage.addNotification(receiver, sender, type, category, categoryId, content, link, options);
 
-    sendNotification(receiver, dbName);
+    sendNotification(receiver);
   }
 
-  public void setNotificationsAsRead(String user, String type, String category, String categoryId, String dbName)
+  public void setNotificationsAsRead(String user, String type, String category, String categoryId)
   {
-    storage.setNotificationsAsRead(user, type, category, categoryId, dbName);
+    storage.setNotificationsAsRead(user, type, category, categoryId);
 
-    sendNotification(user, dbName);
+    sendNotification(user);
   }
 
   @Override
-  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String dbName) {
-    return getUnreadNotifications(user, userService, null, null, null, dbName);
+  public List<NotificationBean> getUnreadNotifications(String user, UserService userService) {
+    return getUnreadNotifications(user, userService, null, null, null);
   }
 
   @Override
-  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String type, String category, String categoryId, String dbName) {
-    return storage.getUnreadNotifications(user, userService, type, category, categoryId, dbName);
+  public List<NotificationBean> getUnreadNotifications(String user, UserService userService, String type, String category, String categoryId) {
+    return storage.getUnreadNotifications(user, userService, type, category, categoryId);
   }
 
-  public int getUnreadNotificationsTotal(String user, String dbName)
+  public int getUnreadNotificationsTotal(String user)
   {
-    return getUnreadNotificationsTotal(user, null, null, null, dbName);
+    return getUnreadNotificationsTotal(user, null, null, null);
   }
 
 
-  public int getUnreadNotificationsTotal(String user, String type, String category, String categoryId, String dbName)
+  public int getUnreadNotificationsTotal(String user, String type, String category, String categoryId)
   {
-    return storage.getUnreadNotificationsTotal(user, type, category, categoryId, dbName);
+    return storage.getUnreadNotificationsTotal(user, type, category, categoryId);
   }
 
-  public int getNumberOfNotifications(String dbName)
+  public int getNumberOfNotifications()
   {
-    return storage.getNumberOfNotifications(dbName);
+    return storage.getNumberOfNotifications();
   }
 
-  public int getNumberOfUnreadNotifications(String dbName)
+  public int getNumberOfUnreadNotifications()
   {
-    return storage.getNumberOfUnreadNotifications(dbName);
+    return storage.getNumberOfUnreadNotifications();
   }
 
-  private void sendNotification(String receiver, String dbName) {
+  private void sendNotification(String receiver) {
     Map<String, Object> data = new HashMap<>();
-    data.put("totalUnreadMsg", getUnreadNotificationsTotal(receiver, dbName));
+    data.put("totalUnreadMsg", getUnreadNotificationsTotal(receiver));
 
     // Deliver the saved message to sender's subscribed channel itself.
     RealTimeMessageBean messageBean = new RealTimeMessageBean(

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/SettingDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/SettingDataStorage.java
@@ -23,7 +23,7 @@ package org.exoplatform.chat.services;
  * Setting data storage
  */
 public interface SettingDataStorage {
-  String getSetting(String name, String dbName);
+  String getSetting(String name);
 
-  void setSetting(String name, String value, String dbName);
+  void setSetting(String name, String value);
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/TokenServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/TokenServiceImpl.java
@@ -51,27 +51,22 @@ public class TokenServiceImpl implements TokenService
 
   public boolean hasUserWithToken(String user, String token)
   {
-    return hasUserWithToken(user, token, null);
+    return storage.hasUserWithToken(user, token);
   }
 
-  public boolean hasUserWithToken(String user, String token, String dbName)
+  public void addUser(String user, String token)
   {
-    return storage.hasUserWithToken(user, token, dbName);
+    storage.addUser(user, token);
   }
 
-  public void addUser(String user, String token, String dbName)
+  public void removeUserToken(String user, String token)
   {
-    storage.addUser(user, token, dbName);
+    storage.removeUserToken(user, token);
   }
 
-  public void removeUserToken(String user, String token, String dbName)
+  public Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitUsers, boolean withUsers, boolean withPublic, boolean isAdmin, int limit)
   {
-    storage.removeUserToken(user, token, dbName);
-  }
-
-  public Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitUsers, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit)
-  {
-    return storage.getActiveUsersFilterBy(user, limitUsers, dbName, withUsers, withPublic, isAdmin, limit);
+    return storage.getActiveUsersFilterBy(user, limitUsers, withUsers, withPublic, isAdmin, limit);
   }
 
   public boolean isDemoUser(String user)

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/TokenStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/TokenStorage.java
@@ -26,11 +26,11 @@ import java.util.Map;
 
 public interface TokenStorage
 {
-  boolean hasUserWithToken(String user, String token, String dbName);
+  boolean hasUserWithToken(String user, String token);
 
-  void addUser(String user, String token, String dbName);
+  void addUser(String user, String token);
 
-  void removeUserToken(String user, String token, String dbName);
+  void removeUserToken(String user, String token);
 
-  Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitedFilter, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit);
+  Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitedFilter, boolean withUsers, boolean withPublic, boolean isAdmin, int limit);
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/UserDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/UserDataStorage.java
@@ -26,9 +26,9 @@ public interface UserDataStorage {
   public static final String ROOM_NOTIF_TRIGGER_WHEN_KEY_WORD = "keywords";
   public static final String NOTIFICATIONS_SETTINGS = "notificationsSettings";
 
-  void addFavorite(String user, String targetUser, String dbName);
+  void addFavorite(String user, String targetUser);
 
-  void removeFavorite(String user, String targetUser, String dbName);
+  void removeFavorite(String user, String targetUser);
 
   /*
     * This methode is responsible for setting a notification channel for a specific user
@@ -37,7 +37,7 @@ public interface UserDataStorage {
     *  -desktop
     *  -bip
     */
-  void setPreferredNotification(String user, String notifManner, String dbName) throws Exception;
+  void setPreferredNotification(String user, String notifManner) throws Exception;
 
   /*
     * This methode is responsible for setting a notification triggers for a specific user
@@ -46,7 +46,7 @@ public interface UserDataStorage {
     *  -even-on-do-not-disturb
     *
     */
-  void setNotificationTrigger(String user, String notifCond, String dbName) throws Exception;
+  void setNotificationTrigger(String user, String notifCond) throws Exception;
 
   /*
     * This methode is responsible for setting a notification triggers for a specific user in a specific room
@@ -55,50 +55,50 @@ public interface UserDataStorage {
     *  -key-words
     *
     */
-  void setRoomNotificationTrigger(String user, String room, String notifCond, String notifConditionType, String dbName, long time) throws Exception;
+  void setRoomNotificationTrigger(String user, String room, String notifCond, String notifConditionType, long time) throws Exception;
 
   /*
     * This methode is responsible for getting all desktop settings in a single object
     */
-  NotificationSettingsBean getUserDesktopNotificationSettings(String user, String dbName) throws JSONException;
+  NotificationSettingsBean getUserDesktopNotificationSettings(String user) throws JSONException;
 
-  boolean isFavorite(String user, String targetUser, String dbName);
+  boolean isFavorite(String user, String targetUser);
 
-  void addUserFullName(String user, String fullname, String dbName);
+  void addUserFullName(String user, String fullname);
 
-  void addUserEmail(String user, String email, String dbName);
+  void addUserEmail(String user, String email);
 
-  void setSpaces(String user, List<SpaceBean> spaces, String dbName);
+  void setSpaces(String user, List<SpaceBean> spaces);
 
-  void addTeamRoom(String user, String teamRoomId, String dbName);
+  void addTeamRoom(String user, String teamRoomId);
 
-  void removeTeamUsers(String teamRoomId, List<String> users, String dbName);
+  void removeTeamUsers(String teamRoomId, List<String> users);
 
-  List<RoomBean> getTeams(String user, String dbName);
+  List<RoomBean> getTeams(String user);
 
-  RoomBean getRoom(String user, String roomId, String dbName);
+  RoomBean getRoom(String user, String roomId);
 
-  List<SpaceBean> getSpaces(String user, String dbName);
+  List<SpaceBean> getSpaces(String user);
 
-  List<UserBean> getUsers(String roomId, String filter, int limit, String dbName);
+  List<UserBean> getUsers(String roomId, String filter, int limit);
 
-  List<UserBean> getUsersInRoomChatOneToOne(String roomId, String dbName);
+  List<UserBean> getUsersInRoomChatOneToOne(String roomId);
 
-  String setStatus(String user, String status, String dbName);
+  String setStatus(String user, String status);
 
-  void setAsAdmin(String user, boolean isAdmin, String dbName);
+  void setAsAdmin(String user, boolean isAdmin);
 
-  boolean isAdmin(String user, String dbName);
+  boolean isAdmin(String user);
 
-  String getStatus(String user, String dbName);
+  String getStatus(String user);
 
-  String getUserFullName(String user, String dbName);
+  String getUserFullName(String user);
 
-  UserBean getUser(String user, String dbName);
+  UserBean getUser(String user);
 
-  UserBean getUser(String user, boolean withFavorites, String dbName);
+  UserBean getUser(String user, boolean withFavorites);
 
-  List<String> getUsersFilterBy(String user, String room, String type, String dbName);
+  List<String> getUsersFilterBy(String user, String room, String type);
 
-  int getNumberOfUsers(String dbName);
+  int getNumberOfUsers();
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/UserServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/UserServiceImpl.java
@@ -44,17 +44,17 @@ public class UserServiceImpl implements UserService {
   @Inject
   private RealTimeMessageService realTimeMessageService;
 
-  public void toggleFavorite(String user, String targetUser, String dbName) {
-    if (isFavorite(user, targetUser, dbName)) {
-      removeFavorite(user, targetUser, dbName);
+  public void toggleFavorite(String user, String targetUser) {
+    if (isFavorite(user, targetUser)) {
+      removeFavorite(user, targetUser);
     } else {
-      addFavorite(user, targetUser, dbName);
+      addFavorite(user, targetUser);
     }
   }
 
   @Override
-  public void addFavorite(String user, String room, String dbname) {
-    userStorage.addFavorite(user, room, dbname);
+  public void addFavorite(String user, String room) {
+    userStorage.addFavorite(user, room);
 
     // Deliver the saved message to sender's subscribed channel itself.
     RealTimeMessageBean messageBean = new RealTimeMessageBean(
@@ -67,8 +67,8 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public void removeFavorite(String user, String room, String dbName) {
-    userStorage.removeFavorite(user, room, dbName);
+  public void removeFavorite(String user, String room) {
+    userStorage.removeFavorite(user, room);
 
     // Deliver the saved message to sender's subscribed channel itself.
     RealTimeMessageBean messageBean = new RealTimeMessageBean(
@@ -87,8 +87,8 @@ public class UserServiceImpl implements UserService {
    *  -desktop
    *  -bip
    */
-  public void setPreferredNotification(String user, String notifManner, String dbName) throws Exception {
-    userStorage.setPreferredNotification(user, notifManner, dbName);
+  public void setPreferredNotification(String user, String notifManner) throws Exception {
+    userStorage.setPreferredNotification(user, notifManner);
   }
 
   /**
@@ -98,8 +98,8 @@ public class UserServiceImpl implements UserService {
    *  -even-on-do-not-disturb
    *
    */
-  public void setNotificationTrigger(String user, String notifCond, String dbName) throws Exception {
-    userStorage.setNotificationTrigger(user, notifCond, dbName);
+  public void setNotificationTrigger(String user, String notifCond) throws Exception {
+    userStorage.setNotificationTrigger(user, notifCond);
   }
 
   /**
@@ -109,38 +109,38 @@ public class UserServiceImpl implements UserService {
    *  -key-words
    *
    */
-  public void setRoomNotificationTrigger(String user, String room, String notifCondition, String notifConditionType, String dbName, long time) throws Exception {
-    userStorage.setRoomNotificationTrigger(user, room, notifCondition, notifConditionType, dbName, time);
+  public void setRoomNotificationTrigger(String user, String room, String notifCondition, String notifConditionType, long time) throws Exception {
+    userStorage.setRoomNotificationTrigger(user, room, notifCondition, notifConditionType, time);
   }
 
   /*
   * This method is responsible for getting all desktop settings in a single object
   */
-  public NotificationSettingsBean getUserDesktopNotificationSettings(String user, String dbName) throws JSONException {
-    return userStorage.getUserDesktopNotificationSettings(user, dbName);
+  public NotificationSettingsBean getUserDesktopNotificationSettings(String user) throws JSONException {
+    return userStorage.getUserDesktopNotificationSettings(user);
   }
 
-  public boolean isFavorite(String user, String targetUser, String dbName) {
-    return userStorage.isFavorite(user, targetUser, dbName);
+  public boolean isFavorite(String user, String targetUser) {
+    return userStorage.isFavorite(user, targetUser);
   }
 
-  public void addUserFullName(String user, String fullname, String dbName) {
-    userStorage.addUserFullName(user, fullname, dbName);
+  public void addUserFullName(String user, String fullname) {
+    userStorage.addUserFullName(user, fullname);
   }
 
-  public void addUserEmail(String user, String email, String dbName) {
-    userStorage.addUserEmail(user, email, dbName);
+  public void addUserEmail(String user, String email) {
+    userStorage.addUserEmail(user, email);
   }
 
-  public void setSpaces(String user, List<SpaceBean> spaces, String dbName) {
-    userStorage.setSpaces(user, spaces, dbName);
+  public void setSpaces(String user, List<SpaceBean> spaces) {
+    userStorage.setSpaces(user, spaces);
   }
 
-  public void addTeamRoom(String user, String teamRoomId, String dbName) {
-    userStorage.addTeamRoom(user, teamRoomId, dbName);
+  public void addTeamRoom(String user, String teamRoomId) {
+    userStorage.addTeamRoom(user, teamRoomId);
 
     // Send a websocket message of type 'room-member-joined' to the new room member
-    JSONObject data = getRoom(user, teamRoomId, dbName).toJSONObject();
+    JSONObject data = getRoom(user, teamRoomId).toJSONObject();
     RealTimeMessageBean joinRoomMessage = new RealTimeMessageBean(
         RealTimeMessageBean.EventType.ROOM_MEMBER_JOIN,
         teamRoomId,
@@ -150,79 +150,79 @@ public class UserServiceImpl implements UserService {
     realTimeMessageService.sendMessage(joinRoomMessage, user);
   }
 
-  public void addTeamUsers(String teamRoomId, List<String> users, String dbName) {
+  public void addTeamUsers(String teamRoomId, List<String> users) {
     for (String user:users) {
-      this.addTeamRoom(user, teamRoomId, dbName);
+      this.addTeamRoom(user, teamRoomId);
     }
   }
 
-  public void removeTeamUsers(String teamRoomId, List<String> users, String dbName) {
-    userStorage.removeTeamUsers(teamRoomId, users, dbName);
+  public void removeTeamUsers(String teamRoomId, List<String> users) {
+    userStorage.removeTeamUsers(teamRoomId, users);
   }
 
-  public List<RoomBean> getTeams(String user, String dbName) {
-    return userStorage.getTeams(user, dbName);
+  public List<RoomBean> getTeams(String user) {
+    return userStorage.getTeams(user);
   }
 
-  public RoomBean getRoom(String user, String roomId, String dbName) {
-    return userStorage.getRoom(user, roomId, dbName);
+  public RoomBean getRoom(String user, String roomId) {
+    return userStorage.getRoom(user, roomId);
   }
 
-  public List<SpaceBean> getSpaces(String user, String dbName) {
-    return userStorage.getSpaces(user, dbName);
+  public List<SpaceBean> getSpaces(String user) {
+    return userStorage.getSpaces(user);
   }
 
-  public List<UserBean> getUsersInRoomChatOneToOne(String roomId, String dbName) {
-    return userStorage.getUsersInRoomChatOneToOne(roomId, dbName);
+  public List<UserBean> getUsersInRoomChatOneToOne(String roomId) {
+    return userStorage.getUsersInRoomChatOneToOne(roomId);
   }
 
-  public List<UserBean> getUsers(String roomId, String dbName) {
-    return userStorage.getUsers(roomId, null, 0, dbName);
+  public List<UserBean> getUsers(String roomId) {
+    return userStorage.getUsers(roomId, null, 0);
   }
 
-  public List<UserBean> getUsers(String filter, boolean fullBean, String dbName) {
-    return userStorage.getUsers(null, filter, 0, dbName);
+  public List<UserBean> getUsers(String filter, boolean fullBean) {
+    return userStorage.getUsers(null, filter, 0);
   }
 
-  public List<UserBean> getUsers(String roomId, String filter, int limit, String dbName) {
-    return userStorage.getUsers(roomId, filter, limit, dbName);
+  public List<UserBean> getUsers(String roomId, String filter, int limit) {
+    return userStorage.getUsers(roomId, filter, limit);
   }
 
-  public String setStatus(String user, String status, String dbName) {
-    return userStorage.setStatus(user, status, dbName);
+  public String setStatus(String user, String status) {
+    return userStorage.setStatus(user, status);
   }
 
-  public void setAsAdmin(String user, boolean isAdmin, String dbName) {
-    userStorage.setAsAdmin(user, isAdmin, dbName);
+  public void setAsAdmin(String user, boolean isAdmin) {
+    userStorage.setAsAdmin(user, isAdmin);
   }
 
-  public boolean isAdmin(String user, String dbName) {
-    return userStorage.isAdmin(user, dbName);
+  public boolean isAdmin(String user) {
+    return userStorage.isAdmin(user);
   }
 
-  public String getStatus(String user, String dbName) {
-    return userStorage.getStatus(user, dbName);
+  public String getStatus(String user) {
+    return userStorage.getStatus(user);
   }
 
-  public String getUserFullName(String user, String dbName)
+  public String getUserFullName(String user)
   {
-    return userStorage.getUserFullName(user, dbName);
+    return userStorage.getUserFullName(user);
   }
 
-  public UserBean getUser(String user, String dbName)
+  public UserBean getUser(String user)
   {
-    return getUser(user, false, dbName);
+    return getUser(user, false);
   }
 
-  public UserBean getUser(String user, boolean withFavorites, String dbName) {
-    return userStorage.getUser(user, withFavorites, dbName);
+  public UserBean getUser(String user, boolean withFavorites) {
+    return userStorage.getUser(user, withFavorites);
   }
 
-  public List<String> getUsersFilterBy(String user, String room, String type, String dbName) {
-    return userStorage.getUsersFilterBy(user, room, type, dbName);
+  public List<String> getUsersFilterBy(String user, String room, String type) {
+    return userStorage.getUsersFilterBy(user, room, type);
   }
 
-  public int getNumberOfUsers(String dbName) {
-    return userStorage.getNumberOfUsers(dbName);
+  public int getNumberOfUsers() {
+    return userStorage.getNumberOfUsers();
   }
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/SettingMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/SettingMongoDataStorage.java
@@ -44,18 +44,14 @@ public class SettingMongoDataStorage implements SettingDataStorage {
 
   public static final String M_SETTINGS_COLLECTION = "settings";
 
-  private DB db(String dbName)
+  private DB db()
   {
-    if (StringUtils.isEmpty(dbName)) {
-      return ConnectionManager.getInstance().getDB();
-    } else {
-      return ConnectionManager.getInstance().getDB(dbName);
-    }
+    return ConnectionManager.getInstance().getDB();
   }
 
   @Override
-  public String getSetting(String name, String dbName) {
-    DBCollection coll = db(dbName).getCollection(M_SETTINGS_COLLECTION);
+  public String getSetting(String name) {
+    DBCollection coll = db().getCollection(M_SETTINGS_COLLECTION);
 
     BasicDBObject query = new BasicDBObject();
     query.put("name", name);
@@ -68,8 +64,8 @@ public class SettingMongoDataStorage implements SettingDataStorage {
   }
 
   @Override
-  public void setSetting(String name, String value, String dbName) {
-    DBCollection settingsCol = db(dbName).getCollection("settings");
+  public void setSetting(String name, String value) {
+    DBCollection settingsCol = db().getCollection("settings");
 
     BasicDBObject query = new BasicDBObject();
     query.put("name", name);

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/TokenMongoService.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/TokenMongoService.java
@@ -43,13 +43,9 @@ public class TokenMongoService implements TokenStorage
 {
   public static final String M_USERS_COLLECTION = "users";
 
-  private DB db(String dbName)
+  private DB db()
   {
-    if (StringUtils.isEmpty(dbName)) {
-      return ConnectionManager.getInstance().getDB();
-    } else {
-      return ConnectionManager.getInstance().getDB(dbName);
-    }
+    return ConnectionManager.getInstance().getDB();
   }
 
   public String getToken(String user)
@@ -60,9 +56,9 @@ public class TokenMongoService implements TokenStorage
     return token;
   }
 
-  public boolean hasUserWithToken(String user, String token, String dbName)
+  public boolean hasUserWithToken(String user, String token)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     query.put("token", token);
@@ -70,11 +66,11 @@ public class TokenMongoService implements TokenStorage
     return (cursor.hasNext());
   }
 
-  public void addUser(String user, String token, String dbName)
+  public void addUser(String user, String token)
   {
-    if (!hasUserWithToken(user, token, dbName))
+    if (!hasUserWithToken(user, token))
     {
-      DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+      DBCollection coll = db().getCollection(M_USERS_COLLECTION);
 
       BasicDBObject query = new BasicDBObject();
       query.put("user", user);
@@ -98,9 +94,9 @@ public class TokenMongoService implements TokenStorage
     }
   }
 
-  public void removeUserToken(String user, String token, String dbName)
+  public void removeUserToken(String user, String token)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     query.put("token", token);
@@ -110,7 +106,7 @@ public class TokenMongoService implements TokenStorage
     coll.update(query, set);
   }
 
-  public Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitedFilter, String dbName, boolean withUsers, boolean withPublic, boolean isAdmin, int limit)
+  public Map<String, UserBean> getActiveUsersFilterBy(String user, List<String> limitedFilter, boolean withUsers, boolean withPublic, boolean isAdmin, int limit)
   {
     BasicDBObject query = new BasicDBObject();
     if (isAdmin) {
@@ -125,7 +121,7 @@ public class TokenMongoService implements TokenStorage
     query.put("user", new BasicDBObject("$in", limitedFilter));
     if (limit < 0) limit = 0;
 
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     DBCursor cursor = coll.find(query).limit(limit);
     HashMap<String, UserBean> users = new HashMap<>();
     while (cursor.hasNext()) {

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -49,19 +49,15 @@ public class UserMongoDataStorage implements UserDataStorage {
 
   public static final String DEFAULT_ENABLED_CHANNELS  = "[ \"desktop\" , \"on-site\" , \"bip\"]";
 
-  private DB db(String dbName)
+  private DB db()
   {
-    if (StringUtils.isEmpty(dbName)) {
-      return ConnectionManager.getInstance().getDB();
-    } else {
-      return ConnectionManager.getInstance().getDB(dbName);
-    }
+    return ConnectionManager.getInstance().getDB();
   }
 
   @Override
-  public void addFavorite(String user, String targetUser, String dbName)
+  public void addFavorite(String user, String targetUser)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -81,9 +77,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void removeFavorite(String user, String targetUser, String dbName)
+  public void removeFavorite(String user, String targetUser)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -103,8 +99,8 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void setPreferredNotification(String user, String notifManner, String dbName) throws Exception {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+  public void setPreferredNotification(String user, String notifManner) throws Exception {
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -160,8 +156,8 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void setNotificationTrigger(String user, String notifCond, String dbName) throws Exception {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+  public void setNotificationTrigger(String user, String notifCond) throws Exception {
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -214,8 +210,8 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void setRoomNotificationTrigger(String user, String room, String notifCond, String notifConditionType, String dbName, long time) throws Exception {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+  public void setRoomNotificationTrigger(String user, String room, String notifCond, String notifConditionType, long time) throws Exception {
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -278,9 +274,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   * This methode is responsible for getting all desktop settings in a single object
   */
   @Override
-  public NotificationSettingsBean getUserDesktopNotificationSettings(String user, String dbName) throws JSONException {
+  public NotificationSettingsBean getUserDesktopNotificationSettings(String user) throws JSONException {
     NotificationSettingsBean settings = new NotificationSettingsBean();
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -308,9 +304,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public boolean isFavorite(String user, String targetUser, String dbName)
+  public boolean isFavorite(String user, String targetUser)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -327,9 +323,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void addUserFullName(String user, String fullname, String dbName)
+  public void addUserFullName(String user, String fullname)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -351,9 +347,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void addUserEmail(String user, String email, String dbName)
+  public void addUserEmail(String user, String email)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -375,10 +371,10 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void setSpaces(String user, List<SpaceBean> spaces, String dbName)
+  public void setSpaces(String user, List<SpaceBean> spaces)
   {
     List<String> spaceIds = new ArrayList<String>();
-    DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
+    DBCollection coll = db().getCollection(M_ROOMS_COLLECTION);
     for (SpaceBean bean:spaces)
     {
       String room = ChatUtils.getRoomId(bean.getId());
@@ -415,7 +411,7 @@ public class UserMongoDataStorage implements UserDataStorage {
 
 
     }
-    coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -436,10 +432,10 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void addTeamRoom(String user, String teamRoomId, String dbName) {
+  public void addTeamRoom(String user, String teamRoomId) {
     List<String> teamIds = new ArrayList<String>();
     teamIds.add(teamRoomId);
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -470,8 +466,8 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void removeTeamUsers(String teamRoomId, List<String> users, String dbName) {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+  public void removeTeamUsers(String teamRoomId, List<String> users) {
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     for (String user:users)
     {
       BasicDBObject query = new BasicDBObject();
@@ -495,10 +491,10 @@ public class UserMongoDataStorage implements UserDataStorage {
     }
   }
 
-  private RoomBean getTeam(String teamId, String dbName)
+  private RoomBean getTeam(String teamId)
   {
     RoomBean roomBean = null;
-    DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
+    DBCollection coll = db().getCollection(M_ROOMS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("_id", teamId);
     DBCursor cursor = coll.find(query);
@@ -523,9 +519,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public List<RoomBean> getTeams(String user, String dbName) {
+  public List<RoomBean> getTeams(String user) {
     List<RoomBean> rooms = new ArrayList<RoomBean>();
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -538,7 +534,7 @@ public class UserMongoDataStorage implements UserDataStorage {
       {
         for (String room:listrooms)
         {
-          rooms.add(getTeam(room, dbName));
+          rooms.add(getTeam(room));
         }
       }
 
@@ -547,9 +543,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public RoomBean getRoom(String user, String roomId, String dbName) {
+  public RoomBean getRoom(String user, String roomId) {
     RoomBean roomBean = null;
-    DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
+    DBCollection coll = db().getCollection(M_ROOMS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("_id", roomId);
     DBCursor cursor = coll.find(query);
@@ -583,7 +579,7 @@ public class UserMongoDataStorage implements UserDataStorage {
         users.remove(user);
         String targetUser = users.get(0);
         roomBean.setUser(targetUser);
-        roomBean.setFullName(this.getUserFullName(targetUser, dbName));
+        roomBean.setFullName(this.getUserFullName(targetUser));
       }
       else if (ChatService.TYPE_ROOM_EXTERNAL.equals(type))
       {
@@ -595,10 +591,10 @@ public class UserMongoDataStorage implements UserDataStorage {
     return roomBean;
   }
 
-  private SpaceBean getSpace(String roomId, String dbName)
+  private SpaceBean getSpace(String roomId)
   {
     SpaceBean spaceBean = null;
-    DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
+    DBCollection coll = db().getCollection(M_ROOMS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("_id", roomId);
     DBCursor cursor = coll.find(query);
@@ -621,10 +617,10 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public List<SpaceBean> getSpaces(String user, String dbName)
+  public List<SpaceBean> getSpaces(String user)
   {
     List<SpaceBean> spaces = new ArrayList<SpaceBean>();
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -637,7 +633,7 @@ public class UserMongoDataStorage implements UserDataStorage {
       {
         for (String space:listspaces)
         {
-          spaces.add(getSpace(space, dbName));
+          spaces.add(getSpace(space));
         }
       }
 
@@ -646,9 +642,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public List<UserBean> getUsersInRoomChatOneToOne(String roomId, String dbName) {
+  public List<UserBean> getUsersInRoomChatOneToOne(String roomId) {
     List<UserBean> users = new ArrayList<UserBean>();
-    DBCollection coll = db(dbName).getCollection(M_ROOMS_COLLECTION);
+    DBCollection coll = db().getCollection(M_ROOMS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("_id", roomId);
     DBCursor cursor = coll.find(query);
@@ -657,13 +653,13 @@ public class UserMongoDataStorage implements UserDataStorage {
       Object objectUsers = doc.get("users");
       ArrayList myArrayList = (ArrayList) objectUsers;
       for (int i = 0; i < myArrayList.size(); i++) {
-        users.add(getUser(myArrayList.get(i).toString(), dbName));
+        users.add(getUser(myArrayList.get(i).toString()));
       }
     }
     return users;
   }
 
-  public List<UserBean> getUsers(String roomId, String filter, int limit, String dbName) {
+  public List<UserBean> getUsers(String roomId, String filter, int limit) {
     if (roomId == null && filter == null) {
       throw new IllegalArgumentException();
     }
@@ -695,7 +691,7 @@ public class UserMongoDataStorage implements UserDataStorage {
     }
 
     DBObject query = new BasicDBObject("$and", andList);
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     DBCursor cursor = coll.find(query).limit(limit);
     List<UserBean> users = new ArrayList<>();
     while (cursor.hasNext()) {
@@ -714,9 +710,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public String setStatus(String user, String status, String dbName)
+  public String setStatus(String user, String status)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -738,9 +734,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public void setAsAdmin(String user, boolean isAdmin, String dbName)
+  public void setAsAdmin(String user, boolean isAdmin)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -761,9 +757,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public boolean isAdmin(String user, String dbName)
+  public boolean isAdmin(String user)
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -777,10 +773,10 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public String getStatus(String user, String dbName)
+  public String getStatus(String user)
   {
     String status = STATUS_NONE;
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -790,21 +786,21 @@ public class UserMongoDataStorage implements UserDataStorage {
       if (doc.containsField("status"))
         status = doc.get("status").toString();
       else
-        status = setStatus(user, STATUS_AVAILABLE, dbName);
+        status = setStatus(user, STATUS_AVAILABLE);
     }
     else
     {
-      status = setStatus(user, STATUS_AVAILABLE, dbName);
+      status = setStatus(user, STATUS_AVAILABLE);
     }
 
     return status;
   }
 
   @Override
-  public String getUserFullName(String user, String dbName)
+  public String getUserFullName(String user)
   {
     String fullname = null;
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -819,16 +815,16 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public UserBean getUser(String user, String dbName)
+  public UserBean getUser(String user)
   {
-    return getUser(user, false, dbName);
+    return getUser(user, false);
   }
 
   @Override
-  public UserBean getUser(String user, boolean withFavorites, String dbName)
+  public UserBean getUser(String user, boolean withFavorites)
   {
     UserBean userBean = new UserBean();
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     query.put("user", user);
     DBCursor cursor = coll.find(query);
@@ -854,10 +850,10 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public List<String> getUsersFilterBy(String user, String room, String type, String dbName)
+  public List<String> getUsersFilterBy(String user, String room, String type)
   {
     ArrayList<String> users = new ArrayList<String>();
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     if (ChatService.TYPE_ROOM_SPACE.equals(type))
       query.put("spaces", room);
@@ -876,9 +872,9 @@ public class UserMongoDataStorage implements UserDataStorage {
   }
 
   @Override
-  public int getNumberOfUsers(String dbName)
+  public int getNumberOfUsers()
   {
-    DBCollection coll = db(dbName).getCollection(M_USERS_COLLECTION);
+    DBCollection coll = db().getCollection(M_USERS_COLLECTION);
     BasicDBObject query = new BasicDBObject();
     DBCursor cursor = coll.find(query);
     return cursor.count();

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/upgrade/FavoritesMigrationService.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/upgrade/FavoritesMigrationService.java
@@ -68,10 +68,10 @@ public class FavoritesMigrationService {
     MongoBootstrap mongoBootstrap = ConnectionManager.getInstance();
     DB db = mongoBootstrap.getDB();
 
-    FavoritesMigrationStatus migrationStatus = getMigrationStatus(db.getName());
+    FavoritesMigrationStatus migrationStatus = getMigrationStatus();
 
     if(migrationStatus == null) {
-      setMigrationStatus(FavoritesMigrationStatus.RUNNING, db.getName());
+      setMigrationStatus(FavoritesMigrationStatus.RUNNING);
 
       LOG.info("== Chat users favorites migration starting ==");
 
@@ -94,22 +94,22 @@ public class FavoritesMigrationService {
         }
       }
 
-      setMigrationStatus(FavoritesMigrationStatus.DONE, db.getName());
+      setMigrationStatus(FavoritesMigrationStatus.DONE);
 
       LOG.info("== Chat users favorites migration done ==");
     }
   }
 
-  public FavoritesMigrationStatus getMigrationStatus(String dbName) {
-    String status = settingDataStorage.getSetting(SETTING_MIGRATION_STATUS, dbName);
+  public FavoritesMigrationStatus getMigrationStatus() {
+    String status = settingDataStorage.getSetting(SETTING_MIGRATION_STATUS);
     if(status != null) {
       return FavoritesMigrationStatus.valueOf(status);
     }
     return null;
   }
 
-  public void setMigrationStatus(FavoritesMigrationStatus status, String dbName) {
-    settingDataStorage.setSetting(SETTING_MIGRATION_STATUS, status.toString(), dbName);
+  public void setMigrationStatus(FavoritesMigrationStatus status) {
+    settingDataStorage.setSetting(SETTING_MIGRATION_STATUS, status.toString());
   }
 
   /**

--- a/server-embedded/src/test/java/org/exoplatform/chat/ChatTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/ChatTestCase.java
@@ -28,28 +28,28 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = ServiceBootstrap.getChatService().getRoom(users, null);
-    String roomType = ServiceBootstrap.getChatService().getTypeRoomChat(roomId, null);
+    String roomId = ServiceBootstrap.getChatService().getRoom(users);
+    String roomType = ServiceBootstrap.getChatService().getTypeRoomChat(roomId);
     ConnectionManager.getInstance().getDB().getCollection(ChatMongoDataStorage.M_ROOM_PREFIX+roomType).drop();
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("mary");
-    roomId = ServiceBootstrap.getChatService().getRoom(users, null);
-    roomType = ServiceBootstrap.getChatService().getTypeRoomChat(roomId, null);
+    roomId = ServiceBootstrap.getChatService().getRoom(users);
+    roomType = ServiceBootstrap.getChatService().getTypeRoomChat(roomId);
     ConnectionManager.getInstance().getDB().getCollection(ChatMongoDataStorage.M_ROOM_PREFIX+roomType).drop();
     ConnectionManager.getInstance().getDB().getCollection(ChatMongoDataStorage.M_ROOMS_COLLECTION).drop();
 
     ConnectionManager.getInstance().getDB().getCollection(UserMongoDataStorage.M_USERS_COLLECTION).drop();
 
     UserService userService = ServiceBootstrap.getUserService();
-    userService.addUserFullName("benjamin", "Benjamin Paillereau", null);
-    userService.addUserEmail("benjamin", "bpaillereau@exoplatform.com", null);
-    userService.addUserFullName("john", "John Smith", null);
-    userService.addUserEmail("john", "john@exoplatform.com", null);
-    userService.addUserFullName("mary", "Mary Williams", null);
-    userService.addUserEmail("mary", "mary@exoplatform.com", null);
-    userService.addUserFullName("james", "James Potter", null);
-    userService.addUserEmail("james", "james@exoplatform.com", null);
+    userService.addUserFullName("benjamin", "Benjamin Paillereau");
+    userService.addUserEmail("benjamin", "bpaillereau@exoplatform.com");
+    userService.addUserFullName("john", "John Smith");
+    userService.addUserEmail("john", "john@exoplatform.com");
+    userService.addUserFullName("mary", "Mary Williams");
+    userService.addUserEmail("mary", "mary@exoplatform.com");
+    userService.addUserFullName("james", "James Potter");
+    userService.addUserEmail("james", "james@exoplatform.com");
   }
 
   @Test
@@ -59,19 +59,19 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("john");
     users.add("benjamin");
-    String roomId2 = chatService.getRoom(users, null);
+    String roomId2 = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("mary");
-    String roomId3 = chatService.getRoom(users, null);
+    String roomId3 = chatService.getRoom(users);
 
-    String roomId4 = chatService.getSpaceRoom("test-space", null);
+    String roomId4 = chatService.getSpaceRoom("test-space");
 
     assertEquals(roomId, roomId2);
     assertNotEquals(roomId, roomId3);
@@ -83,9 +83,9 @@ public class ChatTestCase extends AbstractChatTestCase
     ChatService chatService = ServiceBootstrap.getChatService();
     String user = "Benjamin";
     String teamRoomName = "my team Room";
-    String teamRoomId = chatService.getTeamRoom(teamRoomName, user, null);
+    String teamRoomId = chatService.getTeamRoom(teamRoomName, user);
 
-    RoomBean teamRoom = chatService.getTeamRoomById(teamRoomId, null);
+    RoomBean teamRoom = chatService.getTeamRoomById(teamRoomId);
     assertEquals("The room id should be the same", teamRoomId, teamRoom.getRoom());
     assertEquals("The room name should be the same", teamRoomName, teamRoom.getFullName());
     assertEquals("The room owner should be the same", user, teamRoom.getUser());
@@ -102,13 +102,13 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
-    String resp = chatService.read("john", roomId, false, null, null);
+    String resp = chatService.read("john", roomId, false, null);
     String json = "{\"room\": \"" + roomId + "\",\"messages\": []}";
     assertEquals(json, resp);
 
-    resp = chatService.read("john", roomId, true, null, null);
+    resp = chatService.read("john", roomId, true, null);
     String text = "no messages";
     assertEquals(text, resp);
   }
@@ -121,15 +121,15 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
-    chatService.write("foo", "benjamin", roomId, "false", null);
-    String resp = chatService.read("john", roomId, true, null, null);
+    chatService.write("foo", "benjamin", roomId, "false");
+    String resp = chatService.read("john", roomId, true, null);
     assertEquals(47, resp.length());
     assertTrue(resp.endsWith("] Benjamin Paillereau: foo\n"));
 
-    chatService.write("bar", "john", roomId, "false", null);
-    resp = chatService.read("benjamin", roomId, true, null, null);
+    chatService.write("bar", "john", roomId, "false");
+    resp = chatService.read("benjamin", roomId, true, null);
     assertEquals(85, resp.length());
     assertTrue(resp.endsWith("] John Smith: bar\n"));
   }
@@ -141,7 +141,7 @@ public class ChatTestCase extends AbstractChatTestCase
     String roomId = "nonexistingroomid";
 
     try {
-      chatService.write("foo", "john", roomId, "false", null);
+      chatService.write("foo", "john", roomId, "false");
       fail("Sending a message in a non existing room should fail");
     } catch (ChatException e) {
       // expected exception
@@ -157,10 +157,10 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
-    chatService.write("foo", "benjamin", roomId, "false", null);
-    String resp = chatService.read("john", roomId, null);
+    chatService.write("foo", "benjamin", roomId, "false");
+    String resp = chatService.read("john", roomId);
 
     JSONObject jsonObject = (JSONObject)JSONValue.parse(resp);
     String room = (String)jsonObject.get("room");
@@ -172,8 +172,8 @@ public class ChatTestCase extends AbstractChatTestCase
     JSONArray messages = (JSONArray)jsonObject.get("messages");
     assertEquals(1, messages.size());
 
-    chatService.write("bar", "john", roomId, "false", null);
-    resp = chatService.read("benjamin", roomId, null);
+    chatService.write("bar", "john", roomId, "false");
+    resp = chatService.read("benjamin", roomId);
     jsonObject = (JSONObject)JSONValue.parse(resp);
     messages = (JSONArray)jsonObject.get("messages");
     assertEquals(2, messages.size());
@@ -203,10 +203,10 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = chatDataStorage.getRoom(users, null);
+    String roomId = chatDataStorage.getRoom(users);
 
-    chatDataStorage.write("foo", "benjamin", roomId, "false", null);
-    String resp = chatDataStorage.read(roomId, null);
+    chatDataStorage.write("foo", "benjamin", roomId, "false");
+    String resp = chatDataStorage.read(roomId);
     JSONObject jsonObject = (JSONObject)JSONValue.parse(resp);
     JSONArray messages = (JSONArray)jsonObject.get("messages");
     assertEquals(1, messages.size());
@@ -216,9 +216,9 @@ public class ChatTestCase extends AbstractChatTestCase
 
     assertEquals("foo", message);
 
-    chatDataStorage.edit(roomId, "benjamin", id, "bar", null);
+    chatDataStorage.edit(roomId, "benjamin", id, "bar");
 
-    resp = chatDataStorage.read(roomId, null);
+    resp = chatDataStorage.read(roomId);
     jsonObject = (JSONObject)JSONValue.parse(resp);
     messages = (JSONArray)jsonObject.get("messages");
     assertEquals(1, messages.size());
@@ -238,20 +238,20 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId = chatDataStorage.getRoom(users, null);
+    String roomId = chatDataStorage.getRoom(users);
 
-    chatDataStorage.write("foo", "benjamin", roomId, "false", null);
-    chatDataStorage.write("bar", "benjamin", roomId, "false", null);
-    String resp = chatDataStorage.read(roomId, null);
+    chatDataStorage.write("foo", "benjamin", roomId, "false");
+    chatDataStorage.write("bar", "benjamin", roomId, "false");
+    String resp = chatDataStorage.read(roomId);
     JSONObject jsonObject = (JSONObject)JSONValue.parse(resp);
     JSONArray messages = (JSONArray)jsonObject.get("messages");
     assertEquals(2, messages.size());
 
     String id = (String)((JSONObject)messages.get(0)).get("msgId");
 
-    chatDataStorage.delete(roomId, "benjamin", id, null);
+    chatDataStorage.delete(roomId, "benjamin", id);
 
-    resp = chatDataStorage.read(roomId, null);
+    resp = chatDataStorage.read(roomId);
     jsonObject = (JSONObject)JSONValue.parse(resp);
     messages = (JSONArray)jsonObject.get("messages");
     assertEquals(2, messages.size());
@@ -273,26 +273,26 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId1 = chatService.getRoom(users, null);
+    String roomId1 = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("mary");
-    chatService.getRoom(users, null);
+    chatService.getRoom(users);
 
 
-    chatService.write("foo", "benjamin", roomId1, "false", null);
+    chatService.write("foo", "benjamin", roomId1, "false");
 
-    List<RoomBean> rooms = chatService.getExistingRooms("benjamin", false, false, notificationService, tokenService, null);
+    List<RoomBean> rooms = chatService.getExistingRooms("benjamin", false, false, notificationService, tokenService);
     assertEquals(2, rooms.size());
 
-    rooms = chatService.getExistingRooms("john", false, false, notificationService, tokenService, null);
+    rooms = chatService.getExistingRooms("john", false, false, notificationService, tokenService);
     assertEquals(1, rooms.size());
 
-    rooms = chatService.getExistingRooms("mary", false, false, notificationService, tokenService, null);
+    rooms = chatService.getExistingRooms("mary", false, false, notificationService, tokenService);
     assertEquals(1, rooms.size());
 
-    rooms = chatService.getExistingRooms("james", false, false, notificationService, tokenService, null);
+    rooms = chatService.getExistingRooms("james", false, false, notificationService, tokenService);
     assertEquals(0, rooms.size());
 
 
@@ -309,29 +309,29 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId1 = chatService.getRoom(users, null);
+    String roomId1 = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("mary");
-    String roomId2 = chatService.getRoom(users, null);
+    String roomId2 = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("james");
-    String roomId3 = chatService.getRoom(users, null);
+    String roomId3 = chatService.getRoom(users);
 
-    chatService.write("foo", "benjamin", roomId1, "false", null);
-    chatService.write("bar", "john", roomId1, "false", null);
+    chatService.write("foo", "benjamin", roomId1, "false");
+    chatService.write("bar", "john", roomId1, "false");
 
-    chatService.write("foo", "benjamin", roomId2, "false", null);
-    chatService.write("bar", "mary", roomId2, "false", null);
+    chatService.write("foo", "benjamin", roomId2, "false");
+    chatService.write("bar", "mary", roomId2, "false");
 
-    chatService.write("foo", "benjamin", roomId3, "false", null);
-    chatService.write("bar", "james", roomId3, "false", null);
+    chatService.write("foo", "benjamin", roomId3, "false");
+    chatService.write("bar", "james", roomId3, "false");
 
 
-    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces("benjamin", null);
+    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces("benjamin");
     SpaceBean space = new SpaceBean();
     space.setDisplayName("Test Space");
     space.setGroupId("test_space");
@@ -340,7 +340,7 @@ public class ChatTestCase extends AbstractChatTestCase
     space.setTimestamp(System.currentTimeMillis());
     spaces.add(space);
 
-    ServiceBootstrap.getUserService().setSpaces("john", spaces, null);
+    ServiceBootstrap.getUserService().setSpaces("john", spaces);
 
     SpaceBean space2 = new SpaceBean();
     space2.setDisplayName("Test Space 2");
@@ -350,14 +350,14 @@ public class ChatTestCase extends AbstractChatTestCase
     space2.setTimestamp(System.currentTimeMillis());
     spaces.add(space2);
 
-    ServiceBootstrap.getUserService().setSpaces("benjamin", spaces, null);
+    ServiceBootstrap.getUserService().setSpaces("benjamin", spaces);
 
 
-    String spaceId1 = chatService.getSpaceRoom("test_space", null);
-    chatService.write("foo", "benjamin", spaceId1, "false", null);
+    String spaceId1 = chatService.getSpaceRoom("test_space");
+    chatService.write("foo", "benjamin", spaceId1, "false");
 
-    String spaceId2 = chatService.getSpaceRoom("test_space_2", null);
-    chatService.write("foo", "benjamin", spaceId2, "false", null);
+    String spaceId2 = chatService.getSpaceRoom("test_space_2");
+    chatService.write("foo", "benjamin", spaceId2, "false");
 
     //public RoomsBean getRooms(String user, String filter,
     //      boolean withUsers, boolean withSpaces, boolean withPublic, boolean withOffline, boolean isAdmin,
@@ -365,30 +365,30 @@ public class ChatTestCase extends AbstractChatTestCase
 
     RoomsBean roomsBenAll = chatService.getRooms("benjamin", null,
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsMaryAll = chatService.getRooms("mary", null,
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
 
     RoomsBean roomsBenUsers = chatService.getRooms("benjamin", null,
             true, false, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsMaryUsers = chatService.getRooms("mary", null,
             true, false, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsMarySpaces = chatService.getRooms("mary", null,
             false, true, false, false, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
 
     Thread.sleep(110);
 
     RoomsBean roomsBenOffline = chatService.getRooms("benjamin", null,
             true, false, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
 
     RoomsBean roomsBenOnline = chatService.getRooms("benjamin", null,
             true, false, false, false, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
 
     assertEquals(5, roomsBenAll.getRooms().size());
     assertEquals(3, roomsBenUsers.getRooms().size());
@@ -410,29 +410,29 @@ public class ChatTestCase extends AbstractChatTestCase
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
-    String roomId1 = chatService.getRoom(users, null);
+    String roomId1 = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("mary");
-    String roomId2 = chatService.getRoom(users, null);
+    String roomId2 = chatService.getRoom(users);
 
     users = new ArrayList<String>();
     users.add("benjamin");
     users.add("james");
-    String roomId3 = chatService.getRoom(users, null);
+    String roomId3 = chatService.getRoom(users);
 
-    chatService.write("foo", "benjamin", roomId1, "false", null);
-    chatService.write("bar", "john", roomId1, "false", null);
+    chatService.write("foo", "benjamin", roomId1, "false");
+    chatService.write("bar", "john", roomId1, "false");
 
-    chatService.write("foo", "benjamin", roomId2, "false", null);
-    chatService.write("bar", "mary", roomId2, "false", null);
+    chatService.write("foo", "benjamin", roomId2, "false");
+    chatService.write("bar", "mary", roomId2, "false");
 
-    chatService.write("foo", "benjamin", roomId3, "false", null);
-    chatService.write("bar", "james", roomId3, "false", null);
+    chatService.write("foo", "benjamin", roomId3, "false");
+    chatService.write("bar", "james", roomId3, "false");
 
 
-    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces("benjamin", null);
+    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces("benjamin");
     SpaceBean space = new SpaceBean();
     space.setDisplayName("Test Space");
     space.setGroupId("test_space");
@@ -441,7 +441,7 @@ public class ChatTestCase extends AbstractChatTestCase
     space.setTimestamp(System.currentTimeMillis());
     spaces.add(space);
 
-    ServiceBootstrap.getUserService().setSpaces("john", spaces, null);
+    ServiceBootstrap.getUserService().setSpaces("john", spaces);
 
     SpaceBean space2 = new SpaceBean();
     space2.setDisplayName("Test Space 2");
@@ -451,36 +451,36 @@ public class ChatTestCase extends AbstractChatTestCase
     space2.setTimestamp(System.currentTimeMillis());
     spaces.add(space2);
 
-    ServiceBootstrap.getUserService().setSpaces("benjamin", spaces, null);
+    ServiceBootstrap.getUserService().setSpaces("benjamin", spaces);
 
-    String spaceId1 = chatService.getSpaceRoom("test_space", null);
-    chatService.write("foo", "benjamin", spaceId1, "false", null);
+    String spaceId1 = chatService.getSpaceRoom("test_space");
+    chatService.write("foo", "benjamin", spaceId1, "false");
 
-    String spaceId2 = chatService.getSpaceRoom("test_space_2", null);
-    chatService.write("foo", "benjamin", spaceId2, "false", null);
+    String spaceId2 = chatService.getSpaceRoom("test_space_2");
+    chatService.write("foo", "benjamin", spaceId2, "false");
 
     RoomsBean roomsBenAll = chatService.getRooms("benjamin", null,
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
 
     RoomsBean roomsBenTest = chatService.getRooms("benjamin", "Test",
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsBenTeSp = chatService.getRooms("benjamin", "Te Sp",
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsBenTeSpe = chatService.getRooms("benjamin", "Te Spe",
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsBenJohn = chatService.getRooms("benjamin", "john",
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsBenJo = chatService.getRooms("benjamin", "Jo",
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
     RoomsBean roomsBenMaWi = chatService.getRooms("benjamin", "Ma Wi",
             true, true, false, true, false,
-            notificationService, tokenService, null);
+            notificationService, tokenService);
 
     Thread.sleep(110);
 
@@ -508,12 +508,12 @@ public class ChatTestCase extends AbstractChatTestCase
     String normal = ChatService.NOTIFY_ME_ON_ROOM_NORMAL;
     users.add(benjamin);
     users.add(john);
-    String roomId1 = chatService.getRoom(users, null);
+    String roomId1 = chatService.getRoom(users);
     
-    userService.setRoomNotificationTrigger(benjamin, roomId1,"", normal, null, 1000);
-    userService.setRoomNotificationTrigger(benjamin, roomId1,"", "silence", null, 500);
+    userService.setRoomNotificationTrigger(benjamin, roomId1,"", normal, 1000);
+    userService.setRoomNotificationTrigger(benjamin, roomId1,"", "silence", 500);
     
-    NotificationSettingsBean userDNS = userService.getUserDesktopNotificationSettings(benjamin, null);
+    NotificationSettingsBean userDNS = userService.getUserDesktopNotificationSettings(benjamin);
     assertNotNull(userDNS);
     assertTrue(userDNS instanceof NotificationSettingsBean);
   }

--- a/server-embedded/src/test/java/org/exoplatform/chat/NotificationTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/NotificationTestCase.java
@@ -23,8 +23,8 @@ public class NotificationTestCase extends AbstractChatTestCase
   @Test
   public void testAddNotif() throws Exception
   {
-    int tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
-    int tot2 = notificationService_.getUnreadNotificationsTotal(user2, null);
+    int tot1 = notificationService_.getUnreadNotificationsTotal(user1);
+    int tot2 = notificationService_.getUnreadNotificationsTotal(user2);
 
     assertEquals(0, tot1);
     assertEquals(0, tot2);
@@ -32,8 +32,8 @@ public class NotificationTestCase extends AbstractChatTestCase
     notificationService_.addNotification(user1, user2, "type", "cat", "catid", "content", "link", null);
     notificationService_.addNotification(user1, user2, "type", "cat", "catid", "content2", "link", null);
 
-    tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
-    tot2 = notificationService_.getUnreadNotificationsTotal(user2, null);
+    tot1 = notificationService_.getUnreadNotificationsTotal(user1);
+    tot2 = notificationService_.getUnreadNotificationsTotal(user2);
 
     assertEquals(2, tot1);
     assertEquals(0, tot2);
@@ -43,21 +43,21 @@ public class NotificationTestCase extends AbstractChatTestCase
   @Test
   public void testSetAsRead() throws Exception
   {
-    notificationService_.addNotification(user1, user2, "type", "cat", "catid", "content", "link", null);
-    notificationService_.addNotification(user1, user2, "type", "cat", "catid", "content2", "link", null);
-    notificationService_.addNotification(user2, user1, "type", "cat", "catid", "content", "link", null);
-    notificationService_.addNotification(user2, user1, "type", "cat", "catid", "content2", "link", null);
+    notificationService_.addNotification(user1, user2, "type", "cat", "catid", "content", "link");
+    notificationService_.addNotification(user1, user2, "type", "cat", "catid", "content2", "link");
+    notificationService_.addNotification(user2, user1, "type", "cat", "catid", "content", "link");
+    notificationService_.addNotification(user2, user1, "type", "cat", "catid", "content2", "link");
 
-    int tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
-    int tot2 = notificationService_.getUnreadNotificationsTotal(user2, null);
+    int tot1 = notificationService_.getUnreadNotificationsTotal(user1);
+    int tot2 = notificationService_.getUnreadNotificationsTotal(user2);
 
     assertEquals(2, tot1);
     assertEquals(2, tot2);
 
-    notificationService_.setNotificationsAsRead(user1, null, null, null, null);
+    notificationService_.setNotificationsAsRead(user1, null, null, null);
 
-    tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
-    tot2 = notificationService_.getUnreadNotificationsTotal(user2, null);
+    tot1 = notificationService_.getUnreadNotificationsTotal(user1);
+    tot2 = notificationService_.getUnreadNotificationsTotal(user2);
 
     assertEquals(0, tot1);
     assertEquals(2, tot2);
@@ -73,19 +73,19 @@ public class NotificationTestCase extends AbstractChatTestCase
     notificationService_.addNotification(user1, user2, "type", "othercat", "catid", "content2", "link", null);
     notificationService_.addNotification(user1, user2, "type", "othercat", "catid", "content2", "link", null);
 
-    int tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
+    int tot1 = notificationService_.getUnreadNotificationsTotal(user1);
     assertEquals(5, tot1);
 
-    notificationService_.setNotificationsAsRead(user1, "type", "cat", "catid", null);
-    tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
+    notificationService_.setNotificationsAsRead(user1, "type", "cat", "catid");
+    tot1 = notificationService_.getUnreadNotificationsTotal(user1);
     assertEquals(3, tot1);
 
-    notificationService_.setNotificationsAsRead(user1, "type", "othercat", "othercatid", null);
-    tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
+    notificationService_.setNotificationsAsRead(user1, "type", "othercat", "othercatid");
+    tot1 = notificationService_.getUnreadNotificationsTotal(user1);
     assertEquals(3, tot1);
 
-    notificationService_.setNotificationsAsRead(user1, "type", "othercat", "catid", null);
-    tot1 = notificationService_.getUnreadNotificationsTotal(user1, null);
+    notificationService_.setNotificationsAsRead(user1, "type", "othercat", "catid");
+    tot1 = notificationService_.getUnreadNotificationsTotal(user1);
     assertEquals(0, tot1);
 
   }
@@ -100,10 +100,10 @@ public class NotificationTestCase extends AbstractChatTestCase
     notificationService_.addNotification(user1, user2, "type", "othercat", "catid", "content2", "link", null);
     notificationService_.addNotification(user1, user2, "type", "othercat", "catid", "content2", "link", null);
 
-    int total = notificationService_.getUnreadNotificationsTotal(user1, null);
-    int totcat = notificationService_.getUnreadNotificationsTotal(user1, "type", "cat", "catid", null);
-    int totothercat = notificationService_.getUnreadNotificationsTotal(user1, "type", "othercat", "catid", null);
-    int totnone = notificationService_.getUnreadNotificationsTotal(user1, "type", "othercat", "othercatid", null);
+    int total = notificationService_.getUnreadNotificationsTotal(user1);
+    int totcat = notificationService_.getUnreadNotificationsTotal(user1, "type", "cat", "catid");
+    int totothercat = notificationService_.getUnreadNotificationsTotal(user1, "type", "othercat", "catid");
+    int totnone = notificationService_.getUnreadNotificationsTotal(user1, "type", "othercat", "othercatid");
 
     assertEquals(5, total);
     assertEquals(2, totcat);

--- a/server-embedded/src/test/java/org/exoplatform/chat/SpaceTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/SpaceTestCase.java
@@ -20,12 +20,12 @@ public class SpaceTestCase extends AbstractChatTestCase
   public void setUp()
   {
     ConnectionManager.getInstance().getDB().getCollection(UserMongoDataStorage.M_USERS_COLLECTION).drop();
-    ServiceBootstrap.getUserService().addUserFullName("benjamin", "Benjamin Paillereau", null);
-    ServiceBootstrap.getUserService().addUserEmail("benjamin", "bpaillereau@exoplatform.com", null);
-    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith", null);
-    ServiceBootstrap.getUserService().addUserEmail("john", "john@exoplatform.com", null);
-    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams", null);
-    ServiceBootstrap.getUserService().addUserEmail("mary", "mary@exoplatform.com", null);
+    ServiceBootstrap.getUserService().addUserFullName("benjamin", "Benjamin Paillereau");
+    ServiceBootstrap.getUserService().addUserEmail("benjamin", "bpaillereau@exoplatform.com");
+    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith");
+    ServiceBootstrap.getUserService().addUserEmail("john", "john@exoplatform.com");
+    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams");
+    ServiceBootstrap.getUserService().addUserEmail("mary", "mary@exoplatform.com");
   }
 
   @Test
@@ -34,7 +34,7 @@ public class SpaceTestCase extends AbstractChatTestCase
     log.info("SpaceTestCase.testSpaces");
     String user = "benjamin";
 
-    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces(user, null);
+    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces(user);
     assertEquals(0, spaces.size());
     SpaceBean space = new SpaceBean();
     space.setDisplayName("Test Space");
@@ -43,9 +43,9 @@ public class SpaceTestCase extends AbstractChatTestCase
     space.setShortName("Test Space");
     space.setTimestamp(System.currentTimeMillis());
     spaces.add(space);
-    ServiceBootstrap.getUserService().setSpaces(user, spaces, null);
+    ServiceBootstrap.getUserService().setSpaces(user, spaces);
 
-    spaces = ServiceBootstrap.getUserService().getSpaces(user, null);
+    spaces = ServiceBootstrap.getUserService().getSpaces(user);
     assertEquals(1, spaces.size());
 
     SpaceBean space2 = new SpaceBean();
@@ -55,19 +55,19 @@ public class SpaceTestCase extends AbstractChatTestCase
     space2.setShortName("Test Space 2");
     space2.setTimestamp(System.currentTimeMillis());
     spaces.add(space2);
-    ServiceBootstrap.getUserService().setSpaces(user, spaces, null);
+    ServiceBootstrap.getUserService().setSpaces(user, spaces);
 
-    spaces = ServiceBootstrap.getUserService().getSpaces(user, null);
+    spaces = ServiceBootstrap.getUserService().getSpaces(user);
     assertEquals(2, spaces.size());
 
     spaces = new ArrayList<SpaceBean>();
     spaces.add(space);
-    ServiceBootstrap.getUserService().setSpaces(user, spaces, null);
-    spaces = ServiceBootstrap.getUserService().getSpaces(user, null);
+    ServiceBootstrap.getUserService().setSpaces(user, spaces);
+    spaces = ServiceBootstrap.getUserService().getSpaces(user);
     assertEquals(1, spaces.size());
 
 
-    spaces = ServiceBootstrap.getUserService().getSpaces("john", null);
+    spaces = ServiceBootstrap.getUserService().getSpaces("john");
     assertEquals(0, spaces.size());
 
   }
@@ -76,7 +76,7 @@ public class SpaceTestCase extends AbstractChatTestCase
   public void testSpace() throws Exception
   {
     String user = "benjamin";
-    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces(user, null);
+    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces(user);
     SpaceBean space = new SpaceBean();
     String displayName = "Test Space";
     String spaceId = "123456789";
@@ -88,9 +88,9 @@ public class SpaceTestCase extends AbstractChatTestCase
     space.setShortName("Test Space");
     space.setTimestamp(System.currentTimeMillis());
     spaces.add(space);
-    ServiceBootstrap.getUserService().setSpaces(user, spaces, null);
+    ServiceBootstrap.getUserService().setSpaces(user, spaces);
 
-    SpaceBean target = ServiceBootstrap.getUserService().getSpaces(user, null).get(0);
+    SpaceBean target = ServiceBootstrap.getUserService().getSpaces(user).get(0);
 
     assertEquals(space, target);
 
@@ -100,7 +100,7 @@ public class SpaceTestCase extends AbstractChatTestCase
   public void testSpaceUsers() throws Exception
   {
     String user = "benjamin";
-    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces(user, null);
+    List<SpaceBean> spaces = ServiceBootstrap.getUserService().getSpaces(user);
     SpaceBean space = new SpaceBean();
     String displayName = "Test Space";
     String spaceId = "123456789";
@@ -113,13 +113,13 @@ public class SpaceTestCase extends AbstractChatTestCase
     space.setTimestamp(System.currentTimeMillis());
     spaces.add(space);
 
-    ServiceBootstrap.getUserService().setSpaces(user, spaces, null);
-    ServiceBootstrap.getUserService().setSpaces("john", spaces, null);
+    ServiceBootstrap.getUserService().setSpaces(user, spaces);
+    ServiceBootstrap.getUserService().setSpaces("john", spaces);
 
-    assertEquals(2, ServiceBootstrap.getUserService().getUsers(space.getRoom(), null).size());
+    assertEquals(2, ServiceBootstrap.getUserService().getUsers(space.getRoom()).size());
 
-    ServiceBootstrap.getUserService().setSpaces("mary", spaces, null);
-    assertEquals(3, ServiceBootstrap.getUserService().getUsers(space.getRoom(), null).size());
+    ServiceBootstrap.getUserService().setSpaces("mary", spaces);
+    assertEquals(3, ServiceBootstrap.getUserService().getUsers(space.getRoom()).size());
 
     SpaceBean space2 = new SpaceBean();
     String displayName2 = "Test Space 2";
@@ -133,9 +133,9 @@ public class SpaceTestCase extends AbstractChatTestCase
     space2.setTimestamp(System.currentTimeMillis());
     spaces.add(space2);
 
-    ServiceBootstrap.getUserService().setSpaces("mary", spaces, null);
-    assertEquals(1, ServiceBootstrap.getUserService().getUsers(space2.getRoom(), null).size());
-    assertEquals(3, ServiceBootstrap.getUserService().getUsers(space.getRoom(), null).size());
+    ServiceBootstrap.getUserService().setSpaces("mary", spaces);
+    assertEquals(1, ServiceBootstrap.getUserService().getUsers(space2.getRoom()).size());
+    assertEquals(3, ServiceBootstrap.getUserService().getUsers(space.getRoom()).size());
 
   }
 

--- a/server-embedded/src/test/java/org/exoplatform/chat/TeamTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/TeamTestCase.java
@@ -22,12 +22,12 @@ public class TeamTestCase extends AbstractChatTestCase
   {
     ConnectionManager.getInstance().getDB().getCollection(UserMongoDataStorage.M_USERS_COLLECTION).drop();
     ConnectionManager.getInstance().getDB().getCollection(ChatMongoDataStorage.M_ROOMS_COLLECTION).drop();
-    ServiceBootstrap.getUserService().addUserFullName("benjamin", "Benjamin Paillereau", null);
-    ServiceBootstrap.getUserService().addUserEmail("benjamin", "bpaillereau@exoplatform.com", null);
-    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith", null);
-    ServiceBootstrap.getUserService().addUserEmail("john", "john@exoplatform.com", null);
-    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams", null);
-    ServiceBootstrap.getUserService().addUserEmail("mary", "mary@exoplatform.com", null);
+    ServiceBootstrap.getUserService().addUserFullName("benjamin", "Benjamin Paillereau");
+    ServiceBootstrap.getUserService().addUserEmail("benjamin", "bpaillereau@exoplatform.com");
+    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith");
+    ServiceBootstrap.getUserService().addUserEmail("john", "john@exoplatform.com");
+    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams");
+    ServiceBootstrap.getUserService().addUserEmail("mary", "mary@exoplatform.com");
   }
 
   @Test
@@ -37,16 +37,16 @@ public class TeamTestCase extends AbstractChatTestCase
     String user = "benjamin";
     String user2 = "john";
 
-    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user, null);
-    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team 2", user, null);
-    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user2, null);
+    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user);
+    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team 2", user);
+    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user2);
 
     assertNotEquals(room1, room2);
     assertNotEquals(room1, room3);
 
-    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room1, null));
-    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room2, null));
-    assertEquals(user2, ServiceBootstrap.getChatService().getTeamCreator(room3, null));
+    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room1));
+    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room2));
+    assertEquals(user2, ServiceBootstrap.getChatService().getTeamCreator(room3));
 
   }
 
@@ -57,16 +57,16 @@ public class TeamTestCase extends AbstractChatTestCase
     String user = "benjamin";
     String user2 = "john";
 
-    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user, null);
-    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team 2", user, null);
-    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user2, null);
+    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user);
+    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team 2", user);
+    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user2);
 
     assertNotEquals(room1, room2);
     assertNotEquals(room1, room3);
 
-    assertEquals(2, ServiceBootstrap.getChatService().getTeamRoomsByName("My VIP Team", null).size());
-    assertEquals(1, ServiceBootstrap.getChatService().getTeamRoomsByName("My VIP Team 2", null).size());
-    assertEquals(0, ServiceBootstrap.getChatService().getTeamRoomsByName("Not existing room", null).size());
+    assertEquals(2, ServiceBootstrap.getChatService().getTeamRoomsByName("My VIP Team").size());
+    assertEquals(1, ServiceBootstrap.getChatService().getTeamRoomsByName("My VIP Team 2").size());
+    assertEquals(0, ServiceBootstrap.getChatService().getTeamRoomsByName("Not existing room").size());
 
   }
 
@@ -78,17 +78,17 @@ public class TeamTestCase extends AbstractChatTestCase
     String teamName = "My Team to Delete";
 
     // create a team room
-    String roomId = ServiceBootstrap.getChatService().getTeamRoom(teamName, user, null);
-    RoomBean room = ServiceBootstrap.getChatService().getTeamRoomById(roomId, null);
+    String roomId = ServiceBootstrap.getChatService().getTeamRoom(teamName, user);
+    RoomBean room = ServiceBootstrap.getChatService().getTeamRoomById(roomId);
     assertNotNull("The room should exist", room);
 
     // delete the Team Room
-    ServiceBootstrap.getChatService().deleteTeamRoom(roomId, user, null);
+    ServiceBootstrap.getChatService().deleteTeamRoom(roomId, user);
 
-    List<String> members = ServiceBootstrap.getUserService().getUsersFilterBy(null, roomId, ChatService.TYPE_ROOM_TEAM, null);
+    List<String> members = ServiceBootstrap.getUserService().getUsersFilterBy(null, roomId, ChatService.TYPE_ROOM_TEAM);
     assertTrue("No user should be member of the deleted Team Room", members.isEmpty());
 
-    RoomBean roomDelete = ServiceBootstrap.getChatService().getTeamRoomById(roomId, null);
+    RoomBean roomDelete = ServiceBootstrap.getChatService().getTeamRoomById(roomId);
     assertNull("The room should have been deleted", roomDelete);
 
   }
@@ -102,15 +102,15 @@ public class TeamTestCase extends AbstractChatTestCase
     String roomTeamName = "RoomTeam";
 
     // create a team room
-    String roomTeamId = ServiceBootstrap.getChatService().getTeamRoom(roomTeamName, user, null);
-    RoomBean roomTeam = ServiceBootstrap.getChatService().getTeamRoomById(roomTeamId, null);
+    String roomTeamId = ServiceBootstrap.getChatService().getTeamRoom(roomTeamName, user);
+    RoomBean roomTeam = ServiceBootstrap.getChatService().getTeamRoomById(roomTeamId);
     assertNotNull("The room should exists", roomTeam);
     assertEquals("The room name is not good", roomTeamName, roomTeam.getFullName());
     assertEquals("The room owner is not good", user, roomTeam.getUser());
 
     // create a space room
-    String roomId = ServiceBootstrap.getChatService().getSpaceRoom(roomSpaceName, null);
-    RoomBean room = ServiceBootstrap.getChatService().getTeamRoomById(roomId, null); // nothing should be loaded
+    String roomId = ServiceBootstrap.getChatService().getSpaceRoom(roomSpaceName);
+    RoomBean room = ServiceBootstrap.getChatService().getTeamRoomById(roomId); // nothing should be loaded
     assertNull("The team room should not exist", room);
   }
 
@@ -120,7 +120,7 @@ public class TeamTestCase extends AbstractChatTestCase
     log.info("TeamTestCase.testTeamRoomLoadByIdNonExisting");
     String roomId = "non-existing-id";
 
-    RoomBean nullTeamRoom = ServiceBootstrap.getChatService().getTeamRoomById(roomId, null);
+    RoomBean nullTeamRoom = ServiceBootstrap.getChatService().getTeamRoomById(roomId);
     assertNull("The returned room should be null", nullTeamRoom);
   }
 
@@ -131,17 +131,17 @@ public class TeamTestCase extends AbstractChatTestCase
     String user = "benjamin";
     String user2 = "john";
 
-    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user, null);
-    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My Other Team", user, null);
-    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My Last Team", user, null);
+    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user);
+    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My Other Team", user);
+    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My Last Team", user);
 
-    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room1, null));
+    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room1));
 
-    ServiceBootstrap.getUserService().addTeamRoom(user, room1, null);
-    ServiceBootstrap.getUserService().addTeamRoom(user, room2, null);
-    ServiceBootstrap.getUserService().addTeamRoom(user, room3, null);
+    ServiceBootstrap.getUserService().addTeamRoom(user, room1);
+    ServiceBootstrap.getUserService().addTeamRoom(user, room2);
+    ServiceBootstrap.getUserService().addTeamRoom(user, room3);
 
-    List<RoomBean> teams = ServiceBootstrap.getUserService().getTeams(user, null);
+    List<RoomBean> teams = ServiceBootstrap.getUserService().getTeams(user);
     assertEquals(3, teams.size());
 
     List<String> users = new ArrayList<String>();
@@ -150,19 +150,19 @@ public class TeamTestCase extends AbstractChatTestCase
     List<String> usersRemove = new ArrayList<String>();
     usersRemove.add("john");
 
-    List<RoomBean> teamsJohn = ServiceBootstrap.getUserService().getTeams("john", null);
+    List<RoomBean> teamsJohn = ServiceBootstrap.getUserService().getTeams("john");
     assertEquals(0, teamsJohn.size());
 
-    ServiceBootstrap.getUserService().addTeamUsers(room1, users, null);
-    ServiceBootstrap.getUserService().addTeamUsers(room2, users, null);
-    teamsJohn = ServiceBootstrap.getUserService().getTeams("john", null);
+    ServiceBootstrap.getUserService().addTeamUsers(room1, users);
+    ServiceBootstrap.getUserService().addTeamUsers(room2, users);
+    teamsJohn = ServiceBootstrap.getUserService().getTeams("john");
     assertEquals(2, teamsJohn.size());
 
-    ServiceBootstrap.getUserService().removeTeamUsers(room1, usersRemove, null);
-    teamsJohn = ServiceBootstrap.getUserService().getTeams("john", null);
+    ServiceBootstrap.getUserService().removeTeamUsers(room1, usersRemove);
+    teamsJohn = ServiceBootstrap.getUserService().getTeams("john");
     assertEquals(1, teamsJohn.size());
 
-    List<RoomBean> teamsMary = ServiceBootstrap.getUserService().getTeams("mary", null);
+    List<RoomBean> teamsMary = ServiceBootstrap.getUserService().getTeams("mary");
     assertEquals(2, teamsMary.size());
 
 
@@ -175,23 +175,23 @@ public class TeamTestCase extends AbstractChatTestCase
     log.info("TeamTestCase.testTeamUserFilter");
     String user = "benjamin";
 
-    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user, null);
-    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My Other Team", user, null);
-    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My Last Team", user, null);
+    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user);
+    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My Other Team", user);
+    String room3 = ServiceBootstrap.getChatService().getTeamRoom("My Last Team", user);
 
-    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room1, null));
+    assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room1));
 
-    ServiceBootstrap.getUserService().addTeamRoom(user, room1, null);
-    ServiceBootstrap.getUserService().addTeamRoom(user, room2, null);
+    ServiceBootstrap.getUserService().addTeamRoom(user, room1);
+    ServiceBootstrap.getUserService().addTeamRoom(user, room2);
 
     List<String> users = new ArrayList<String>();
     users.add("john");
-    ServiceBootstrap.getUserService().addTeamUsers(room1, users, null);
+    ServiceBootstrap.getUserService().addTeamUsers(room1, users);
 
-    List<String> users1 = ServiceBootstrap.getUserService().getUsersFilterBy(user, room1, ChatService.TYPE_ROOM_TEAM, null);
+    List<String> users1 = ServiceBootstrap.getUserService().getUsersFilterBy(user, room1, ChatService.TYPE_ROOM_TEAM);
     assertEquals(1, users1.size());
 
-    List<String> users2 = ServiceBootstrap.getUserService().getUsersFilterBy(user, room2, ChatService.TYPE_ROOM_TEAM, null);
+    List<String> users2 = ServiceBootstrap.getUserService().getUsersFilterBy(user, room2, ChatService.TYPE_ROOM_TEAM);
     assertEquals(0, users2.size());
   }
 
@@ -201,21 +201,21 @@ public class TeamTestCase extends AbstractChatTestCase
     log.info("TeamTestCase.testTeamRoomName");
     String user = "benjamin";
 
-    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user, null);
-    ServiceBootstrap.getUserService().addTeamRoom(user, room1, null);
+    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user);
+    ServiceBootstrap.getUserService().addTeamRoom(user, room1);
 
     RoomsBean rooms = ServiceBootstrap.getChatService().getRooms(user, "", true, true, true, true, true,
-            ServiceBootstrap.getNotificationService(), ServiceBootstrap.getTokenService(), null);
+            ServiceBootstrap.getNotificationService(), ServiceBootstrap.getTokenService());
 
     assertEquals(1, rooms.getRooms().size());
 
     RoomBean room = rooms.getRooms().get(0);
     assertEquals("My VIP Team", room.getFullName());
 
-    ServiceBootstrap.getChatService().setRoomName(room1, "VIP Team", null);
+    ServiceBootstrap.getChatService().setRoomName(room1, "VIP Team");
 
     rooms = ServiceBootstrap.getChatService().getRooms(user, "", true, true, true, true, true,
-            ServiceBootstrap.getNotificationService(), ServiceBootstrap.getTokenService(), null);
+            ServiceBootstrap.getNotificationService(), ServiceBootstrap.getTokenService());
 
     assertEquals(1, rooms.getRooms().size());
 

--- a/server-embedded/src/test/java/org/exoplatform/chat/UserTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/UserTestCase.java
@@ -38,84 +38,84 @@ public class UserTestCase extends AbstractChatTestCase
   {
     log.info("UserTestCase.testToken");
     String token = ServiceBootstrap.getTokenService().getToken(username);
-    boolean hasToken = ServiceBootstrap.getTokenService().hasUserWithToken(username, token, null);
+    boolean hasToken = ServiceBootstrap.getTokenService().hasUserWithToken(username, token);
     assertFalse(hasToken);
 
-    ServiceBootstrap.getTokenService().addUser(username, token, null);
-    assertTrue(ServiceBootstrap.getTokenService().hasUserWithToken(username, token, null));
+    ServiceBootstrap.getTokenService().addUser(username, token);
+    assertTrue(ServiceBootstrap.getTokenService().hasUserWithToken(username, token));
   }
 
   @Test
   public void testUserCreation() throws Exception
   {
     log.info("UserTestCase.testUserCreation");
-    String fullname = ServiceBootstrap.getUserService().getUserFullName(username, null);
+    String fullname = ServiceBootstrap.getUserService().getUserFullName(username);
     assertNull(fullname);
 
-    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau", null);
-    ServiceBootstrap.getUserService().addUserEmail(username, "bpaillereau@exoplatform.com", null);
+    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau");
+    ServiceBootstrap.getUserService().addUserEmail(username, "bpaillereau@exoplatform.com");
 
-    UserBean user = ServiceBootstrap.getUserService().getUser(username, null);
+    UserBean user = ServiceBootstrap.getUserService().getUser(username);
 
     assertEquals("Benjamin Paillereau", user.getFullname());
     assertEquals("bpaillereau@exoplatform.com", user.getEmail());
 
-    ServiceBootstrap.getUserService().setAsAdmin(username, false, null);
+    ServiceBootstrap.getUserService().setAsAdmin(username, false);
 
-    assertFalse(ServiceBootstrap.getUserService().isAdmin(username, null));
+    assertFalse(ServiceBootstrap.getUserService().isAdmin(username));
 
-    assertEquals(1, ServiceBootstrap.getUserService().getNumberOfUsers(null));
+    assertEquals(1, ServiceBootstrap.getUserService().getNumberOfUsers());
 
     String token = ServiceBootstrap.getTokenService().getToken("john");
-    ServiceBootstrap.getTokenService().addUser("john", token, null);
-    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith", null);
+    ServiceBootstrap.getTokenService().addUser("john", token);
+    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith");
 
     token = ServiceBootstrap.getTokenService().getToken("mary");
-    ServiceBootstrap.getTokenService().addUser("mary", token, null);
-    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams", null);
+    ServiceBootstrap.getTokenService().addUser("mary", token);
+    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams");
 
     token = ServiceBootstrap.getTokenService().getToken("james");
-    ServiceBootstrap.getTokenService().addUser("james", token, null);
-    ServiceBootstrap.getUserService().addUserFullName("james", "James Potter", null);
+    ServiceBootstrap.getTokenService().addUser("james", token);
+    ServiceBootstrap.getUserService().addUserFullName("james", "James Potter");
 
-    assertEquals(4, ServiceBootstrap.getUserService().getNumberOfUsers(null));
+    assertEquals(4, ServiceBootstrap.getUserService().getNumberOfUsers());
   }
 
   @Test
   public void testGetUsers() throws Exception
   {
     log.info("UserTestCase.testGetUsers");
-    String fullname = ServiceBootstrap.getUserService().getUserFullName(username, null);
+    String fullname = ServiceBootstrap.getUserService().getUserFullName(username);
     assertNull(fullname);
 
-    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau", null);
-    ServiceBootstrap.getUserService().addUserEmail(username, "bpaillereau@exoplatform.com", null);
+    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau");
+    ServiceBootstrap.getUserService().addUserEmail(username, "bpaillereau@exoplatform.com");
 
     String token = ServiceBootstrap.getTokenService().getToken("john");
-    ServiceBootstrap.getTokenService().addUser("john", token, null);
-    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith", null);
+    ServiceBootstrap.getTokenService().addUser("john", token);
+    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith");
 
     token = ServiceBootstrap.getTokenService().getToken("mary");
-    ServiceBootstrap.getTokenService().addUser("mary", token, null);
-    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams", null);
+    ServiceBootstrap.getTokenService().addUser("mary", token);
+    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams");
 
     token = ServiceBootstrap.getTokenService().getToken("james");
-    ServiceBootstrap.getTokenService().addUser("james", token, null);
-    ServiceBootstrap.getUserService().addUserFullName("james", "James Potter", null);
+    ServiceBootstrap.getTokenService().addUser("james", token);
+    ServiceBootstrap.getUserService().addUserFullName("james", "James Potter");
 
-    int nbUsers = ServiceBootstrap.getUserService().getUsers("", false, null).size();
+    int nbUsers = ServiceBootstrap.getUserService().getUsers("", false).size();
     assertEquals(4, nbUsers);
 
-    int nbJ = ServiceBootstrap.getUserService().getUsers("j", false, null).size();
+    int nbJ = ServiceBootstrap.getUserService().getUsers("j", false).size();
     assertEquals(3, nbJ);
 
-    int nbJame = ServiceBootstrap.getUserService().getUsers("jame", false, null).size();
+    int nbJame = ServiceBootstrap.getUserService().getUsers("jame", false).size();
     assertEquals(1, nbJame);
 
-    int nbBePa = ServiceBootstrap.getUserService().getUsers("be pa", false, null).size();
+    int nbBePa = ServiceBootstrap.getUserService().getUsers("be pa", false).size();
     assertEquals(1, nbBePa);
 
-    int nbBePaUC = ServiceBootstrap.getUserService().getUsers("BE PA", false, null).size();
+    int nbBePaUC = ServiceBootstrap.getUserService().getUsers("BE PA", false).size();
     assertEquals(1, nbBePaUC);
 
   }
@@ -124,7 +124,7 @@ public class UserTestCase extends AbstractChatTestCase
   public void testDemoUser() throws Exception
   {
     log.info("UserTestCase.testDemoUser");
-    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau", null);
+    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau");
 
     assertFalse(ServiceBootstrap.getTokenService().isDemoUser(username));
 
@@ -134,27 +134,27 @@ public class UserTestCase extends AbstractChatTestCase
   public void testFavorites() throws Exception
   {
     log.info("UserTestCase.testFavorites");
-    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau", null);
-    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith", null);
-    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams", null);
+    ServiceBootstrap.getUserService().addUserFullName(username, "Benjamin Paillereau");
+    ServiceBootstrap.getUserService().addUserFullName("john", "John Smith");
+    ServiceBootstrap.getUserService().addUserFullName("mary", "Mary Williams");
 
-    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "john", null));
+    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "john"));
 
-    ServiceBootstrap.getUserService().toggleFavorite(username, "john", null);
-    assertTrue(ServiceBootstrap.getUserService().isFavorite(username, "john", null));
-    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "mary", null));
+    ServiceBootstrap.getUserService().toggleFavorite(username, "john");
+    assertTrue(ServiceBootstrap.getUserService().isFavorite(username, "john"));
+    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "mary"));
 
-    ServiceBootstrap.getUserService().toggleFavorite(username, "john", null);
-    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "john", null));
-    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "mary", null));
+    ServiceBootstrap.getUserService().toggleFavorite(username, "john");
+    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "john"));
+    assertFalse(ServiceBootstrap.getUserService().isFavorite(username, "mary"));
 
-    ServiceBootstrap.getUserService().toggleFavorite(username, "john", null);
-    ServiceBootstrap.getUserService().toggleFavorite(username, "mary", null);
+    ServiceBootstrap.getUserService().toggleFavorite(username, "john");
+    ServiceBootstrap.getUserService().toggleFavorite(username, "mary");
 
-    UserBean user = ServiceBootstrap.getUserService().getUser(username, null);
+    UserBean user = ServiceBootstrap.getUserService().getUser(username);
     assertNull(user.getFavorites());
 
-    user = ServiceBootstrap.getUserService().getUser(username, true, null);
+    user = ServiceBootstrap.getUserService().getUser(username, true);
     assertEquals(2, user.getFavorites().size());
 
   }
@@ -164,21 +164,21 @@ public class UserTestCase extends AbstractChatTestCase
   {
     log.info("UserTestCase.testStatus");
     UserService userService = ServiceBootstrap.getUserService();
-    userService.addUserFullName(username, "Benjamin Paillereau", null);
-    userService.addUserFullName("john", "John Smith", null);
+    userService.addUserFullName(username, "Benjamin Paillereau");
+    userService.addUserFullName("john", "John Smith");
 
-    assertEquals(UserService.STATUS_AVAILABLE, userService.getStatus(username, null));
+    assertEquals(UserService.STATUS_AVAILABLE, userService.getStatus(username));
 
-    userService.setStatus(username, UserService.STATUS_DONOTDISTURB, null);
-    assertEquals(UserService.STATUS_DONOTDISTURB, userService.getStatus(username, null));
+    userService.setStatus(username, UserService.STATUS_DONOTDISTURB);
+    assertEquals(UserService.STATUS_DONOTDISTURB, userService.getStatus(username));
 
-    assertEquals(UserService.STATUS_AVAILABLE, userService.getStatus("john", null));
+    assertEquals(UserService.STATUS_AVAILABLE, userService.getStatus("john"));
 
-    userService.setStatus(username, UserService.STATUS_AWAY, null);
-    assertEquals(UserService.STATUS_AWAY, userService.getStatus(username, null));
+    userService.setStatus(username, UserService.STATUS_AWAY);
+    assertEquals(UserService.STATUS_AWAY, userService.getStatus(username));
 
-    userService.setStatus(username, UserService.STATUS_INVISIBLE, null);
-    assertEquals(UserService.STATUS_INVISIBLE, userService.getStatus(username, null));
+    userService.setStatus(username, UserService.STATUS_INVISIBLE);
+    assertEquals(UserService.STATUS_INVISIBLE, userService.getStatus(username));
 
   }
 
@@ -187,14 +187,14 @@ public class UserTestCase extends AbstractChatTestCase
   {
     log.info("UserTestCase.testAdmin");
     UserService userService = ServiceBootstrap.getUserService();
-    userService.addUserFullName(username, "Benjamin Paillereau", null);
-    userService.addUserFullName("john", "John Smith", null);
+    userService.addUserFullName(username, "Benjamin Paillereau");
+    userService.addUserFullName("john", "John Smith");
 
-    assertFalse(userService.isAdmin(username, null));
+    assertFalse(userService.isAdmin(username));
 
-    userService.setAsAdmin(username, true, null);
+    userService.setAsAdmin(username, true);
 
-    assertTrue(userService.isAdmin(username, null));
+    assertTrue(userService.isAdmin(username));
 
   }
 }

--- a/server-embedded/src/test/java/org/exoplatform/chat/server/ChatServerTest.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/server/ChatServerTest.java
@@ -35,13 +35,13 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("mary");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     String token = tokenService.getToken("john");
-    tokenService.addUser("john", token, null);
+    tokenService.addUser("john", token);
 
     // When
-    Response.Content read = chatServer.read("john", token, roomId, "1", null,"false", "0", null);
+    Response.Content read = chatServer.read("john", token, roomId, "1", null,"false", "0");
 
     // Then
     assertNotNull(read);
@@ -57,13 +57,13 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("mary");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     String token = tokenService.getToken("james");
-    tokenService.addUser("james", token, null);
+    tokenService.addUser("james", token);
 
     // When
-    Response.Content read = chatServer.read("james", token, roomId, "1", null,"false", "0", null);
+    Response.Content read = chatServer.read("james", token, roomId, "1", null,"false", "0");
 
     // Then
     assertNotNull(read);
@@ -80,15 +80,15 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("john");
     users.add("mary");
-    String roomId = chatService.getTeamRoom("myteam", "john", null);
+    String roomId = chatService.getTeamRoom("myteam", "john");
 
-    userService.addTeamUsers(roomId, users, null);
+    userService.addTeamUsers(roomId, users);
 
     String token = tokenService.getToken("john");
-    tokenService.addUser("john", token, null);
+    tokenService.addUser("john", token);
 
     // When
-    Response.Content read = chatServer.read("john", token, roomId, "1", null, "false", "0", null);
+    Response.Content read = chatServer.read("john", token, roomId, "1", null, "false", "0");
 
     // Then
     assertNotNull(read);
@@ -104,14 +104,14 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("john");
     users.add("mary");
-    String roomId = chatService.getTeamRoom("myteam", "john", null);
+    String roomId = chatService.getTeamRoom("myteam", "john");
 
-    userService.addTeamUsers(roomId, users, null);
+    userService.addTeamUsers(roomId, users);
 
     String token = tokenService.getToken("james");
-    tokenService.addUser("james", token, null);
+    tokenService.addUser("james", token);
 
-    Response.Content read = chatServer.read("james", token, roomId, "1", null,"false", "0", null);
+    Response.Content read = chatServer.read("james", token, roomId, "1", null,"false", "0");
 
     assertNotNull(read);
     assertEquals(403, read.getCode());
@@ -130,16 +130,16 @@ public class ChatServerTest extends AbstractChatTestCase {
     mySpace.setGroupId("/spaces/myspace");
     mySpace.setDisplayName("My Space");
     mySpace.setRoom("myspace");
-    userService.setSpaces("john", Collections.singletonList(mySpace), null);
-    userService.setSpaces("mary", Collections.singletonList(mySpace), null);
+    userService.setSpaces("john", Collections.singletonList(mySpace));
+    userService.setSpaces("mary", Collections.singletonList(mySpace));
 
-    String roomId = chatService.getSpaceRoom("myspace", null);
+    String roomId = chatService.getSpaceRoom("myspace");
 
     String token = tokenService.getToken("john");
-    tokenService.addUser("john", token, null);
+    tokenService.addUser("john", token);
 
     // When
-    Response.Content read = chatServer.read("john", token, roomId, "1", null,"false", "0", null);
+    Response.Content read = chatServer.read("john", token, roomId, "1", null,"false", "0");
 
     // Then
     assertNotNull(read);
@@ -159,16 +159,16 @@ public class ChatServerTest extends AbstractChatTestCase {
     mySpace.setGroupId("/spaces/myspace");
     mySpace.setDisplayName("My Space");
     mySpace.setRoom("myspace");
-    userService.setSpaces("john", Collections.singletonList(mySpace), null);
-    userService.setSpaces("mary", Collections.singletonList(mySpace), null);
+    userService.setSpaces("john", Collections.singletonList(mySpace));
+    userService.setSpaces("mary", Collections.singletonList(mySpace));
 
-    String roomId = chatService.getSpaceRoom("myspace", null);
+    String roomId = chatService.getSpaceRoom("myspace");
 
     String token = tokenService.getToken("james");
-    tokenService.addUser("james", token, null);
+    tokenService.addUser("james", token);
 
     // When
-    Response.Content read = chatServer.read("james", token, roomId, "1", null,"false", "0", null);
+    Response.Content read = chatServer.read("james", token, roomId, "1", null,"false", "0");
 
     // Then
     assertNotNull(read);
@@ -185,26 +185,26 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("mary");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     String token = tokenService.getToken("john");
-    tokenService.addUser("john", token, null);
+    tokenService.addUser("john", token);
 
-    chatService.write("my message", "john", roomId, "false", null);
+    chatService.write("my message", "john", roomId, "false");
 
-    String jsonMessages = chatService.read("mary", roomId, null);
+    String jsonMessages = chatService.read("mary", roomId);
     JSONObject jsonObject = (JSONObject) JSONValue.parse(jsonMessages);
     JSONArray messages = (JSONArray) jsonObject.get("messages");
     JSONObject message = (JSONObject) messages.get(0);
     String messageId = (String) message.get("id");
 
     // When
-    Response.Content edit = chatServer.edit("john", token, roomId, messageId, "my new message", null);
+    Response.Content edit = chatServer.edit("john", token, roomId, messageId, "my new message");
 
     // Then
     assertNotNull(edit);
     assertEquals(200, edit.getCode());
-    MessageBean messageBean = chatService.getMessage(roomId, messageId, null);
+    MessageBean messageBean = chatService.getMessage(roomId, messageId);
     assertNotNull(messageBean);
     assertEquals("my new message", messageBean.getMessage());
   }
@@ -219,28 +219,28 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("mary");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     String tokenJohn = tokenService.getToken("john");
-    tokenService.addUser("john", tokenJohn, null);
+    tokenService.addUser("john", tokenJohn);
     String tokenJames = tokenService.getToken("james");
-    tokenService.addUser("james", tokenJames, null);
+    tokenService.addUser("james", tokenJames);
 
-    chatService.write("my message", "john", roomId, "false", null);
+    chatService.write("my message", "john", roomId, "false");
 
-    String jsonMessages = chatService.read("mary", roomId, null);
+    String jsonMessages = chatService.read("mary", roomId);
     JSONObject jsonObject = (JSONObject) JSONValue.parse(jsonMessages);
     JSONArray messages = (JSONArray) jsonObject.get("messages");
     JSONObject message = (JSONObject) messages.get(0);
     String messageId = (String) message.get("id");
 
     // When
-    Response.Content edit = chatServer.edit("james", tokenJames, roomId, messageId, "my new message", null);
+    Response.Content edit = chatServer.edit("james", tokenJames, roomId, messageId, "my new message");
 
     // Then
     assertNotNull(edit);
     assertEquals(404, edit.getCode());
-    MessageBean messageBean = chatService.getMessage(roomId, messageId, null);
+    MessageBean messageBean = chatService.getMessage(roomId, messageId);
     assertNotNull(messageBean);
     assertEquals("my message", messageBean.getMessage());
   }
@@ -255,26 +255,26 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("mary");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     String token = tokenService.getToken("john");
-    tokenService.addUser("john", token, null);
+    tokenService.addUser("john", token);
 
-    chatService.write("my message", "john", roomId, "false", null);
+    chatService.write("my message", "john", roomId, "false");
 
-    String jsonMessages = chatService.read("mary", roomId, null);
+    String jsonMessages = chatService.read("mary", roomId);
     JSONObject jsonObject = (JSONObject) JSONValue.parse(jsonMessages);
     JSONArray messages = (JSONArray) jsonObject.get("messages");
     JSONObject message = (JSONObject) messages.get(0);
     String messageId = (String) message.get("id");
 
     // When
-    Response.Content delete = chatServer.delete("john", token, roomId, messageId, null);
+    Response.Content delete = chatServer.delete("john", token, roomId, messageId);
 
     // Then
     assertNotNull(delete);
     assertEquals(200, delete.getCode());
-    MessageBean messageBean = chatService.getMessage(roomId, messageId, null);
+    MessageBean messageBean = chatService.getMessage(roomId, messageId);
     assertNotNull(messageBean);
     assertEquals(ChatService.TYPE_DELETED, messageBean.getMessage());
   }
@@ -289,28 +289,28 @@ public class ChatServerTest extends AbstractChatTestCase {
     List<String> users = new ArrayList<String>();
     users.add("mary");
     users.add("john");
-    String roomId = chatService.getRoom(users, null);
+    String roomId = chatService.getRoom(users);
 
     String tokenJohn = tokenService.getToken("john");
-    tokenService.addUser("john", tokenJohn, null);
+    tokenService.addUser("john", tokenJohn);
     String tokenJames = tokenService.getToken("james");
-    tokenService.addUser("james", tokenJames, null);
+    tokenService.addUser("james", tokenJames);
 
-    chatService.write("my message", "john", roomId, "false", null);
+    chatService.write("my message", "john", roomId, "false");
 
-    String jsonMessages = chatService.read("mary", roomId, null);
+    String jsonMessages = chatService.read("mary", roomId);
     JSONObject jsonObject = (JSONObject) JSONValue.parse(jsonMessages);
     JSONArray messages = (JSONArray) jsonObject.get("messages");
     JSONObject message = (JSONObject) messages.get(0);
     String messageId = (String) message.get("id");
 
     // When
-    Response.Content delete = chatServer.delete("james", tokenJames, roomId, messageId, null);
+    Response.Content delete = chatServer.delete("james", tokenJames, roomId, messageId);
 
     // Then
     assertNotNull(delete);
     assertEquals(404, delete.getCode());
-    MessageBean messageBean = chatService.getMessage(roomId, messageId, null);
+    MessageBean messageBean = chatService.getMessage(roomId, messageId);
     assertNotNull(messageBean);
     assertEquals("my message", messageBean.getMessage());
   }
@@ -325,19 +325,19 @@ public class ChatServerTest extends AbstractChatTestCase {
     String benjamin = "benjamin";
     String john = "john";
     
-    userService.addUserFullName(benjamin, "Benjamin Paillereau", null);
-    userService.addUserFullName(john, "John Smith", null);
-    userService.toggleFavorite(benjamin, john, null);
+    userService.addUserFullName(benjamin, "Benjamin Paillereau");
+    userService.addUserFullName(john, "John Smith");
+    userService.toggleFavorite(benjamin, john);
 
     String tokenBen = tokenService.getToken(benjamin);
-    tokenService.addUser(benjamin, tokenBen, null);
+    tokenService.addUser(benjamin, tokenBen);
     
     String tokenJohn = tokenService.getToken(john);
-    tokenService.addUser(john, tokenJohn, null);
+    tokenService.addUser(john, tokenJohn);
   
     // When
-    Response.Content isFavoriteBen = chatServer.isFavorite(benjamin, tokenBen, john, null);
-    Response.Content isFavoriteJohn = chatServer.isFavorite(benjamin, tokenJohn, john, null);
+    Response.Content isFavoriteBen = chatServer.isFavorite(benjamin, tokenBen, john);
+    Response.Content isFavoriteJohn = chatServer.isFavorite(benjamin, tokenJohn, john);
     // Then
     assertNotNull(isFavoriteBen);
     assertEquals(200, isFavoriteBen.getCode());

--- a/server-embedded/src/test/java/org/exoplatform/chat/services/mongodb/TokenMongoServiceTest.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/services/mongodb/TokenMongoServiceTest.java
@@ -45,29 +45,29 @@ public class TokenMongoServiceTest extends AbstractChatTestCase {
     tokenService = ServiceBootstrap.getTokenService();
 
     // When
-    userService.addUserFullName("john", "jhon", null);
+    userService.addUserFullName("john", "jhon");
 
     List<String> onlineUsers = new ArrayList<String>();
 
     for (int i = 1; i <= 35; i++) {
       String userId = "john" + i;
-      userService.addUserFullName(userId, userId, null);
-      userService.setStatus(userId, UserService.STATUS_AVAILABLE, null);
+      userService.addUserFullName(userId, userId);
+      userService.setStatus(userId, UserService.STATUS_AVAILABLE);
 
       String tokenId = tokenService.getToken(userId);
-      tokenService.addUser(userId, tokenId, null);
+      tokenService.addUser(userId, tokenId);
 
       onlineUsers.add(userId);
 
       List<String> users = new ArrayList<String>();
       users.add("john");
       users.add(userId);
-      String roomId = chatService.getRoom(users, null);
-      chatService.write("foo", userId, roomId, "false", null);
+      String roomId = chatService.getRoom(users);
+      chatService.write("foo", userId, roomId, "false");
     }
 
     // Then
-    Map<String, UserBean> availableUsers = tokenService.getActiveUsersFilterBy("john", onlineUsers, null, true, true, false, 30);
+    Map<String, UserBean> availableUsers = tokenService.getActiveUsersFilterBy("john", onlineUsers, true, true, false, 30);
     assertEquals("should be 30",30, availableUsers.size());
   }
 }

--- a/server-embedded/src/test/java/org/exoplatform/chat/services/upgrade/FavoritesMigrationServiceTest.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/services/upgrade/FavoritesMigrationServiceTest.java
@@ -46,20 +46,20 @@ public class FavoritesMigrationServiceTest extends AbstractChatTestCase {
   @Test
   public void testUpgradeWithUsersTeamsAndSpacesRoomsInFavorites() {
     // Given
-    userService.addUserFullName("thomas", "Thomas Delhoménie", null);
-    userService.addUserFullName("john", "John Smith", null);
-    userService.addUserFullName("mary", "Mary Williams", null);
-    userService.addUserFullName("james", "James Doe", null);
+    userService.addUserFullName("thomas", "Thomas Delhoménie");
+    userService.addUserFullName("john", "John Smith");
+    userService.addUserFullName("mary", "Mary Williams");
+    userService.addUserFullName("james", "James Doe");
 
-    String roomThomasJohn = chatService.getRoom(Arrays.asList("thomas", "john"), null);
-    String roomThomasMary = chatService.getRoom(Arrays.asList("thomas", "mary"), null);
-    String roomThomasJames = chatService.getRoom(Arrays.asList("thomas", "james"), null);
-    String roomJohnMary = chatService.getRoom(Arrays.asList("john", "mary"), null);
-    String roomTeam1 = chatService.getTeamRoom("Team 1", "thomas", null);
-    String roomTeam2 = chatService.getTeamRoom("Team 2", "thomas", null);
-    String roomSpace1 = chatService.getSpaceRoom("Space 1", null);
-    String roomSpace2 = chatService.getSpaceRoom("Space 2", null);
-    String roomSpace3 = chatService.getSpaceRoom("Space 3", null);
+    String roomThomasJohn = chatService.getRoom(Arrays.asList("thomas", "john"));
+    String roomThomasMary = chatService.getRoom(Arrays.asList("thomas", "mary"));
+    String roomThomasJames = chatService.getRoom(Arrays.asList("thomas", "james"));
+    String roomJohnMary = chatService.getRoom(Arrays.asList("john", "mary"));
+    String roomTeam1 = chatService.getTeamRoom("Team 1", "thomas");
+    String roomTeam2 = chatService.getTeamRoom("Team 2", "thomas");
+    String roomSpace1 = chatService.getSpaceRoom("Space 1");
+    String roomSpace2 = chatService.getSpaceRoom("Space 2");
+    String roomSpace3 = chatService.getSpaceRoom("Space 3");
 
     setOldFavoritesToUser("thomas",
                           Arrays.asList("john",
@@ -73,7 +73,7 @@ public class FavoritesMigrationServiceTest extends AbstractChatTestCase {
     favoritesMigrationService.processMigration();
 
     // Then
-    UserBean thomas = userService.getUser("thomas", true, null);
+    UserBean thomas = userService.getUser("thomas", true);
     assertNotNull(thomas);
     List<String> newThomasFavorites = thomas.getFavorites();
     assertNotNull(newThomasFavorites);
@@ -83,11 +83,11 @@ public class FavoritesMigrationServiceTest extends AbstractChatTestCase {
     assertTrue(newThomasFavorites.contains(roomTeam1));
     assertTrue(newThomasFavorites.contains(roomSpace2));
     assertTrue(newThomasFavorites.contains(roomSpace2));
-    UserBean john = userService.getUser("john", true, null);
+    UserBean john = userService.getUser("john", true);
     assertNotNull(john);
     List<String> newJohnFavorites = john.getFavorites();
     assertNull(newJohnFavorites);
-    UserBean mary = userService.getUser("mary", true, null);
+    UserBean mary = userService.getUser("mary", true);
     assertNotNull(mary);
     List<String> newMaryFavorites = mary.getFavorites();
     assertNotNull(newMaryFavorites);
@@ -96,28 +96,28 @@ public class FavoritesMigrationServiceTest extends AbstractChatTestCase {
     assertTrue(newThomasFavorites.contains(roomSpace3));
 
     assertEquals(FavoritesMigrationService.FavoritesMigrationStatus.DONE,
-                 favoritesMigrationService.getMigrationStatus(db.getName()));
+                 favoritesMigrationService.getMigrationStatus());
   }
 
   @Test
   public void testDoNotUpgradeWhenMigrationAlreadyDone() {
     // Given
-    ServiceBootstrap.getUserService().addUserFullName("thomas", "Thomas Delhoménie", null);
+    ServiceBootstrap.getUserService().addUserFullName("thomas", "Thomas Delhoménie");
 
-    String roomTeam1 = ServiceBootstrap.getChatService().getTeamRoom("Team 1", "thomas", null);
-    String roomSpace1 = ServiceBootstrap.getChatService().getSpaceRoom("Space 1", null);
+    String roomTeam1 = ServiceBootstrap.getChatService().getTeamRoom("Team 1", "thomas");
+    String roomSpace1 = ServiceBootstrap.getChatService().getSpaceRoom("Space 1");
 
     setOldFavoritesToUser("thomas",
                           Arrays.asList(ChatService.TEAM_PREFIX + roomTeam1,
                                         ChatService.SPACE_PREFIX + roomSpace1));
 
-    ServiceBootstrap.getFavoritesMigrationService().setMigrationStatus(FavoritesMigrationService.FavoritesMigrationStatus.DONE, db.getName());
+    ServiceBootstrap.getFavoritesMigrationService().setMigrationStatus(FavoritesMigrationService.FavoritesMigrationStatus.DONE);
 
     // When
     ServiceBootstrap.getFavoritesMigrationService().processMigration();
 
     // Then
-    UserBean thomas = ServiceBootstrap.getUserService().getUser("thomas", true, null);
+    UserBean thomas = ServiceBootstrap.getUserService().getUser("thomas", true);
     assertNotNull(thomas);
     List<String> newThomasFavorites = thomas.getFavorites();
     assertNotNull(newThomasFavorites);
@@ -127,7 +127,7 @@ public class FavoritesMigrationServiceTest extends AbstractChatTestCase {
     assertTrue(newThomasFavorites.contains(ChatService.SPACE_PREFIX + roomSpace1));
 
     assertEquals(FavoritesMigrationService.FavoritesMigrationStatus.DONE,
-            ServiceBootstrap.getFavoritesMigrationService().getMigrationStatus(db.getName()));
+            ServiceBootstrap.getFavoritesMigrationService().getMigrationStatus());
   }
 
   private void setOldFavoritesToUser(String username, List<String> oldFavorites) {

--- a/services/src/main/java/org/exoplatform/addons/chat/api/UserRestService.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/api/UserRestService.java
@@ -149,20 +149,19 @@ public class UserRestService implements ResourceContainer {
     String currentUsername = sc.getUserPrincipal().getName();
 
     String token = ServerBootstrap.getToken(currentUsername);
-    String dbName = ServerBootstrap.getDBName();
-    String userFullName = ServerBootstrap.getUserFullName(currentUsername, dbName);
+    String userFullName = ServerBootstrap.getUserFullName(currentUsername);
 
     Boolean isUserInitialized = (Boolean) request.getSession().getAttribute(CHAT_USER_INITIALIZATION_ATTR);
     if (isUserInitialized == null || !isUserInitialized) {
       // Add User in the DB
-      ServerBootstrap.addUser(currentUsername, token, dbName);
+      ServerBootstrap.addUser(currentUsername, token);
 
       if (StringUtils.isBlank(userFullName)) {
         // Set user's Full Name in the DB
         User user = organizationService.getUserHandler().findUserByName(currentUsername);
         if (user != null) {
           userFullName = user.getDisplayName();
-          ServerBootstrap.addUserFullNameAndEmail(currentUsername, userFullName, user.getEmail(), dbName);
+          ServerBootstrap.addUserFullNameAndEmail(currentUsername, userFullName, user.getEmail());
         }
       }
       request.getSession().setAttribute(CHAT_USER_INITIALIZATION_ATTR, true);
@@ -181,7 +180,7 @@ public class UserRestService implements ResourceContainer {
     } else {
       chatCometDServerUrl = "/cometd/cometd";
     }
-    String userStatus = ServerBootstrap.getStatus(currentUsername, token, currentUsername, dbName);
+    String userStatus = ServerBootstrap.getStatus(currentUsername, token, currentUsername);
 
     JSONObject userSettings = new JSONObject();
     userSettings.put("username", currentUsername);
@@ -190,7 +189,6 @@ public class UserRestService implements ResourceContainer {
     userSettings.put("status", userStatus);
     userSettings.put("isOnline", online);
     userSettings.put("cometdToken", cometdToken);
-    userSettings.put("dbName", dbName);
     userSettings.put("sessionId", request.getSession().getId());
     userSettings.put("serverURL", ServerBootstrap.getServerURL());
     userSettings.put("standalone", isStandalone);

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
@@ -49,53 +49,34 @@ public class ServerBootstrap {
 
   private static String    serverURI = null;
 
-  /**
-   * Get mongo database name for current tenant if on cloud environment
-   */
-  public static String getDBName() {
-    String dbName = "";
-    String prefixDB = PropertyManager.getProperty(PropertyManager.PROPERTY_DB_NAME);
-    ConversationState currentState = ConversationState.getCurrent();
-    if (currentState != null) {
-      dbName = (String) currentState.getAttribute("currentTenant");
-    }
-    if (StringUtils.isEmpty(dbName)) {
-      dbName = prefixDB;
-    } else {
-      StringBuilder sb = new StringBuilder().append(prefixDB).append("_").append(dbName);
-      dbName = sb.toString();
-    }
-    return dbName;
+  public static String getStatus(String username, String token, String targetUser) {
+    return callServer("getStatus", "user=" + username + "&targetUser=" + targetUser + "&token=" + token);
   }
 
-  public static String getStatus(String username, String token, String targetUser, String dbName) {
-    return callServer("getStatus", "user=" + username + "&targetUser=" + targetUser + "&token=" + token + "&dbName=" + dbName);
+  public static String getUsers(String username, String token, String room) {
+    return callServer("users", "user=" + username + "&room=" + room + "&token=" + token);
   }
 
-  public static String getUsers(String username, String token, String room, String dbName) {
-    return callServer("users", "user=" + username + "&dbName=" + dbName + "&room=" + room + "&token=" + token);
+  public static String getUserFullName(String username) {
+    return callServer("getUserFullName", "username=" + username);
   }
 
-  public static String getUserFullName(String username, String dbName) {
-    return callServer("getUserFullName", "username=" + username + "&dbName=" + dbName);
+  public static void addUser(String username, String token) {
+    postServer("addUser", "username=" + username + "&token=" + token);
   }
 
-  public static void addUser(String username, String token, String dbName) {
-    postServer("addUser", "username=" + username + "&token=" + token + "&dbName=" + dbName);
+  public static void logout(String username, String token, String sessionId, boolean uniqueSession) {
+    postServer("logout", "username=" + username + "&token=" + token + "&sessionId=" + sessionId + "&uniqueSession=" + uniqueSession);
   }
 
-  public static void logout(String username, String token, String sessionId, String dbName, boolean uniqueSession) {
-    postServer("logout", "username=" + username + "&token=" + token + "&sessionId=" + sessionId + "&dbName=" + dbName + "&uniqueSession=" + uniqueSession);
+  public static void setAsAdmin(String username, boolean isAdmin) {
+    postServer("setAsAdmin", "username=" + username + "&isAdmin=" + isAdmin);
   }
 
-  public static void setAsAdmin(String username, boolean isAdmin, String dbName) {
-    postServer("setAsAdmin", "username=" + username + "&isAdmin=" + isAdmin + "&dbName=" + dbName);
-  }
-
-  public static void addUserFullNameAndEmail(String username, String fullname, String email, String dbName) {
+  public static void addUserFullNameAndEmail(String username, String fullname, String email) {
     try {
       postServer("addUserFullNameAndEmail",
-                 "username=" + username + "&fullname=" + ChatUtils.toString(fullname) + "&email=" + email + "&dbName=" + dbName);
+                 "username=" + username + "&fullname=" + ChatUtils.toString(fullname) + "&email=" + email);
     } catch (IOException e) {
       LOG.error("Error while updating user information for user {} [ {} ]", username, email, e);
     }
@@ -108,7 +89,7 @@ public class ServerBootstrap {
     return token;
   }
 
-  public static void saveSpaces(String username, String dbName) {
+  public static void saveSpaces(String username) {
     try {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
       ListAccess<Space> spacesListAccess = spaceService.getAccessibleSpacesWithListAccess(username);
@@ -122,13 +103,13 @@ public class ServerBootstrap {
         spaceBean.setShortName(space.getShortName());
         beans.add(spaceBean);
       }
-      setSpaces(username, new SpaceBeans(beans), dbName);
+      setSpaces(username, new SpaceBeans(beans));
     } catch (Exception e) {
       LOG.warn("Error while initializing spaces of User '" + username + "'", e);
     }
   }
 
-  public static void setSpaces(String username, SpaceBeans beans, String dbName) {
+  public static void setSpaces(String username, SpaceBeans beans) {
     String params = "username=" + username;
     String serSpaces = "";
     try {
@@ -138,7 +119,6 @@ public class ServerBootstrap {
       LOG.error("Error encoding spaces", e);
     }
     params += "&spaces=" + serSpaces;
-    params += "&dbName=" + dbName;
     postServer("setSpaces", params);
   }
 

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/SpaceMembershipListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/SpaceMembershipListener.java
@@ -97,7 +97,7 @@ public class SpaceMembershipListener extends SpaceListenerPlugin {
 
   private void saveSpaces(String username) {
     if (StringUtils.isNotBlank(username)) {
-      ServerBootstrap.saveSpaces(username, ServerBootstrap.getDBName());
+      ServerBootstrap.saveSpaces(username);
     }
   }
 }

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserEventListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserEventListener.java
@@ -15,8 +15,7 @@ public class UpdateUserEventListener extends UserEventListener {
       return;
     }
     try {
-      String dbName = ServerBootstrap.getDBName();
-      ServerBootstrap.addUserFullNameAndEmail(user.getUserName(), user.getDisplayName(), user.getEmail(), dbName);
+      ServerBootstrap.addUserFullNameAndEmail(user.getUserName(), user.getDisplayName(), user.getEmail());
     } catch (Exception e) {
       LOG.warn("Can not update firstName/lastName to chatServer", e);
     }

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserStatusListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserStatusListener.java
@@ -38,7 +38,6 @@ public class UpdateUserStatusListener extends Listener<PortalContainer, HttpSess
       // Send logout message to all sessions of the given user in case of a
       // logout, not in platform stop.
       String token = ServerBootstrap.getToken(userId);
-      String dbName = ServerBootstrap.getDBName();
 
       ConversationRegistry conversationRegistry = portalContainer.getComponentInstanceOfType(ConversationRegistry.class);
       List<StateKey> stateKeys = conversationRegistry.getStateKeys(userId);
@@ -49,7 +48,7 @@ public class UpdateUserStatusListener extends Listener<PortalContainer, HttpSess
       StateKey httpStateKey = new HttpSessionStateKey(httpSession);
       String sessionId = httpSession.getId();
       boolean isSingleSession = stateKeys.stream().filter(stateKey -> !stateKey.equals(httpStateKey)).count() == 0;
-      ServerBootstrap.logout(userId, token, sessionId, dbName, isSingleSession);
+      ServerBootstrap.logout(userId, token, sessionId, isSingleSession);
       if (isSingleSession) {
         UserStateService userStateService = portalContainer.getComponentInstanceOfType(UserStateService.class);
         UserStateModel userStateModel = userStateService.getUserState(userId);

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UserLoginListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UserLoginListener.java
@@ -20,6 +20,6 @@ public class UserLoginListener extends Listener<ConversationRegistry, Conversati
     if (StringUtils.isBlank(userId) || StringUtils.equalsIgnoreCase(userId, IdentityConstants.ANONIM)) {
       return;
     }
-    ServerBootstrap.saveSpaces(userId, ServerBootstrap.getDBName());
+    ServerBootstrap.saveSpaces(userId);
   }
 }

--- a/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
+++ b/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
@@ -164,11 +164,10 @@ public class DocumentService implements ResourceContainer {
                               @FormParam("uploadId") String uploadId,
                               @FormParam("targetRoom") String targetRoom,
                               @FormParam("targetFullname") String targetFullname,
-                              @FormParam("token") String token,
-                              @FormParam("dbName") String dbName) throws Exception {
+                              @FormParam("token") String token) throws Exception {
     String remoteUser = securityContext.getUserPrincipal().getName();
     String room = targetRoom.replace(ChatService.TEAM_PREFIX, "").replace(ChatService.SPACE_PREFIX, "");
-    String users = targetRoom.startsWith(ChatService.TEAM_PREFIX) ? ServerBootstrap.getUsers(remoteUser, token, room, dbName)
+    String users = targetRoom.startsWith(ChatService.TEAM_PREFIX) ? ServerBootstrap.getUsers(remoteUser, token, room)
                                                                   : null;
     List<String> usernames =
                            targetRoom.startsWith(ChatService.TEAM_PREFIX) ? getUsernamesFromJSON(users)


### PR DESCRIPTION
The dbName paramaters available in the Java API and REST endpoints was used to support multitenancy (each tenant has its own db).

Since multitenancy is not supported anymore, we can get rid of this parameter.
So this fix removes this parameter everywhere.