### PR TITLE
Fix/chat-1050: Make sure that Start/Stop meeting button is synchronized between participants of the room.

### DIFF
--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -269,6 +269,24 @@ export function saveRoom(userSettings, roomName, users, room) {
   });
 }
 
+export function updateRoomMeetingStatus(userSettings, room, start, startTime) {
+  const data = {
+    user: userSettings.username,
+    room: room,
+    start: start,
+    startTime: startTime
+  };
+
+  return fetch(`${chatConstants.CHAT_SERVER_API}updateRoomMeetingStatus`, {
+    headers: {
+      'Authorization': `Bearer ${userSettings.token}`,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    },
+    method: 'post',
+    body: decodeURI($.param(data))
+  });
+}
+
 export function getUserAvatar(user) {
   return `${chatConstants.SOCIAL_USER_API}${user}/avatar`;
 }

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -11,7 +11,7 @@
       <exo-chat-contact-list :contacts="contactList" :selected="selectedContact" :loading-contacts="loadingContacts" @open-side-menu="sideMenuArea = !sideMenuArea" @load-more-contacts="loadMoreContacts" @search-contact="searchContacts" @contact-selected="setSelectedContact" @refresh-contacts="refreshContacts($event)"></exo-chat-contact-list>
     </div>
     <div v-show="(selectedContact && (selectedContact.room || selectedContact.user)) || mq === 'mobile'" class="uiGlobalRoomsContainer">
-      <exo-chat-room-detail v-if="Object.keys(selectedContact).length !== 0" :contact="selectedContact" @back-to-contact-list="conversationArea = false"></exo-chat-room-detail>
+      <exo-chat-room-detail v-if="Object.keys(selectedContact).length !== 0" :meeting-started="selectedContact.meetingStarted" :contact="selectedContact" @back-to-contact-list="conversationArea = false"></exo-chat-room-detail>
       <div class="room-content">
         <exo-chat-message-list :contact="selectedContact"></exo-chat-message-list>
         <exo-chat-room-participants :contact="selectedContact" @particpants-loaded="setContactParticipants($event)" @back-to-conversation="participantsArea = false"></exo-chat-room-participants> 

--- a/common/src/main/java/org/exoplatform/chat/model/RoomBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/RoomBean.java
@@ -35,6 +35,8 @@ public class RoomBean implements Comparable<RoomBean>
   boolean isAvailableUser = false;
   String status = UserService.STATUS_INVISIBLE;
   String type = null;
+  boolean meetingStarted = false;
+  String startTime = "";
   boolean isFavorite = false;
   String[] admins = null;
   long timestamp = -1;
@@ -143,6 +145,22 @@ public class RoomBean implements Comparable<RoomBean>
     return l.compareTo(r);
   }
 
+  public boolean isMeetingStarted() {
+    return meetingStarted;
+  }
+
+  public void setMeetingStarted(boolean meetingStarted) {
+    this.meetingStarted = meetingStarted;
+  }
+
+  public String getStartTime() {
+    return startTime;
+  }
+
+  public void setStartTime(String startTime) {
+    this.startTime = startTime;
+  }
+
   @SuppressWarnings("unchecked")
   public JSONObject toJSONObject() {
     JSONObject obj = new JSONObject();
@@ -155,6 +173,8 @@ public class RoomBean implements Comparable<RoomBean>
     obj.put("isActive", String.valueOf(this.isActive()));
     obj.put("isFavorite", this.isFavorite());
     obj.put("type", this.getType());
+    obj.put("meetingStarted", this.isMeetingStarted());
+    obj.put("startTime", this.getStartTime());
     obj.put("lastMessage", this.getLastMessage());
     obj.put("prettyName", this.getPrettyName());
     if (this.getAdmins() != null) {
@@ -170,4 +190,5 @@ public class RoomBean implements Comparable<RoomBean>
   public String toJSON()
   {
     return toJSONObject().toString();
-  }}
+  }
+}

--- a/common/src/main/java/org/exoplatform/chat/model/SpaceBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/SpaceBean.java
@@ -27,6 +27,8 @@ public class SpaceBean implements java.io.Serializable
   String groupId;
   String shortName;
   String prettyName;
+  boolean meetingStarted = false;
+  String startTime = "";
   long timestamp = -1;
 
   public String getPrettyName() {
@@ -35,6 +37,22 @@ public class SpaceBean implements java.io.Serializable
 
   public void setPrettyName(String prettyName) {
     this.prettyName = prettyName;
+  }
+
+  public boolean isMeetingStarted() {
+    return meetingStarted;
+  }
+
+  public void setMeetingStarted(boolean meetingStarted) {
+    this.meetingStarted = meetingStarted;
+  }
+
+  public String getStartTime() {
+    return startTime;
+  }
+
+  public void setStartTime(String startTime) {
+    this.startTime = startTime;
   }
 
   public String getId() {

--- a/common/src/main/java/org/exoplatform/chat/services/ChatService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/ChatService.java
@@ -95,6 +95,8 @@ public interface ChatService
   public String getTeamCreator(String room);
 
   public void setRoomName(String room, String name);
+  
+  public void setRoomMeetingStatus(String room, boolean start, String startTime);
 
   /**
    * Get rooms by name

--- a/common/src/test/java/org/exoplatform/chat/utils/PropertyManagerTestCase.java
+++ b/common/src/test/java/org/exoplatform/chat/utils/PropertyManagerTestCase.java
@@ -78,6 +78,7 @@ public class PropertyManagerTestCase {
 
     Assert.assertEquals("/rest/state/status/", PropertyManager.getProperty(PropertyManager.PROPERTY_PLF_USER_STATUS_UPDATE_URL));
     Assert.assertEquals("15000", PropertyManager.getProperty(PropertyManager.PROPERTY_REQUEST_TIMEOUT));
+    Assert.assertNull(PropertyManager.getProperty("No key"));
   }
 
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -807,6 +807,18 @@ public class ChatServer
   }
 
   @Resource
+  @Route("/updateRoomMeetingStatus")
+  public Response.Content updateRoomMeetingStatus(String user, String token, String start, String room, String startTime) {
+    if (!tokenService.hasUserWithToken(user, token)) {
+      return Response.notFound("Petit malin !");
+    }
+    
+    chatService.setRoomMeetingStatus(room, Boolean.parseBoolean(start), startTime);
+
+    return Response.ok("Updated.");
+  }
+
+  @Resource
   @MimeType("text/plain")
   @Route("/updateUnreadMessages")
   public Response.Content updateUnreadMessages(String room, String user, String token)

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatDataStorage.java
@@ -80,6 +80,8 @@ public interface ChatDataStorage
   public String getTeamCreator(String room);
 
   public void setRoomName(String room, String name);
+  
+  public void setRoomMeetingStatus(String room, boolean start, String startTime);
 
   /**
    * Retrieve a Room by its ID

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
@@ -287,6 +287,11 @@ public class ChatServiceImpl implements ChatService
     }
   }
 
+  @Override
+  public void setRoomMeetingStatus(String room, boolean start, String startTime) {
+    chatStorage.setRoomMeetingStatus(room, start, startTime);
+  }
+
   public String getRoom(List<String> users)
   {
     return chatStorage.getRoom(users);

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -509,6 +509,12 @@ public class UserMongoDataStorage implements UserDataStorage {
       roomBean.setUser(doc.get("user").toString());
       roomBean.setFullName(doc.get("team").toString());
       roomBean.setType(doc.get("type").toString());
+      if (doc.containsField("meetingStarted")) {
+        roomBean.setMeetingStarted((Boolean) doc.get("meetingStarted"));
+      }
+      if (doc.containsField("startTime")) {
+        roomBean.setStartTime((String) doc.get("startTime"));
+      }
       if (doc.containsField("timestamp"))
       {
         roomBean.setTimestamp(((Long) doc.get("timestamp")).longValue());
@@ -568,6 +574,12 @@ public class UserMongoDataStorage implements UserDataStorage {
       {
         roomBean.setUser(ChatService.SPACE_PREFIX+roomId);
         roomBean.setFullName(doc.get("displayName").toString());
+        if (doc.containsField("meetingStarted")) {
+          roomBean.setMeetingStarted((Boolean) doc.get("meetingStarted"));
+        }
+        if (doc.containsField("startTime")) {
+          roomBean.setStartTime((String) doc.get("startTime"));
+        }
       }
       else if (ChatService.TYPE_ROOM_TEAM.equals(type))
       {
@@ -575,6 +587,12 @@ public class UserMongoDataStorage implements UserDataStorage {
         roomBean.setFullName(doc.get("team").toString());
         String creator = (String) doc.get("user");
         roomBean.setAdmins(new String[]{creator});
+        if (doc.containsField("meetingStarted")) {
+          roomBean.setMeetingStarted((Boolean) doc.get("meetingStarted"));
+        }
+        if (doc.containsField("startTime")) {
+          roomBean.setStartTime((String) doc.get("startTime"));
+        }
       }
       else if (ChatService.TYPE_ROOM_USER.equals(type))
       {
@@ -611,6 +629,12 @@ public class UserMongoDataStorage implements UserDataStorage {
       spaceBean.setGroupId(doc.get("groupId").toString());
       spaceBean.setShortName(doc.get("shortName").toString());
       spaceBean.setPrettyName(doc.get("prettyName").toString());
+      if (doc.containsField("meetingStarted")) {
+        spaceBean.setMeetingStarted((Boolean) doc.get("meetingStarted"));
+      }
+      if (doc.containsField("startTime")) {
+        spaceBean.setStartTime((String) doc.get("startTime"));
+      }
       if (doc.containsField("timestamp"))
       {
         spaceBean.setTimestamp(((Long)doc.get("timestamp")).longValue());

--- a/server-embedded/src/test/java/org/exoplatform/chat/TeamTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/TeamTestCase.java
@@ -3,6 +3,7 @@ package org.exoplatform.chat;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.exoplatform.chat.bootstrap.ServiceBootstrap;
@@ -48,6 +49,42 @@ public class TeamTestCase extends AbstractChatTestCase
     assertEquals(user, ServiceBootstrap.getChatService().getTeamCreator(room2));
     assertEquals(user2, ServiceBootstrap.getChatService().getTeamCreator(room3));
 
+  }
+
+  @Test
+  public void testTeamMeetingStatus() throws Exception
+  {
+    log.info("TeamTestCase.testTeamMeetingStatus");
+    String user1 = "mary";
+    String user2 = "john";
+
+    String room1 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team1", user1);
+    String room2 = ServiceBootstrap.getChatService().getTeamRoom("My VIP Team", user2);
+    
+    RoomBean roomBean1 = ServiceBootstrap.getChatService().getTeamRoomById(room1);
+    RoomBean roomBean2 = ServiceBootstrap.getChatService().getTeamRoomById(room2);
+
+    assertFalse(roomBean1.isMeetingStarted());
+    assertFalse(roomBean2.isMeetingStarted());
+    assertTrue(roomBean1.getStartTime().isEmpty());
+    assertTrue(roomBean2.getStartTime().isEmpty());
+
+    Date date = new Date();
+    String now = date.toString();
+    date.setHours(0);
+    String now1 = date.toString();
+    
+    ServiceBootstrap.getChatService().setRoomMeetingStatus(room1,true, now);
+    ServiceBootstrap.getChatService().setRoomMeetingStatus(room2,true, now1);
+
+    roomBean1 = ServiceBootstrap.getChatService().getTeamRoomById(room1);
+    roomBean2 = ServiceBootstrap.getChatService().getTeamRoomById(room2);
+    
+    assertTrue(roomBean1.isMeetingStarted());
+    assertTrue(roomBean2.isMeetingStarted());
+    assertEquals(now, roomBean1.getStartTime());
+    assertEquals(now1, roomBean2.getStartTime());
+    
   }
 
   @Test


### PR DESCRIPTION
The chat room's meeting status is not stored in DB which make it non synchronized for different clients side. As a solution to prevent this issue i made sure to store a new property 'meetingStarted' for RoomBean in order to keep track of meeting status for Team/Space rooms.
Backport for stable/2.3.x