### PR TITLE
Maint-24357 : Fix can't delete a file uploaded from chat one to one. 

### DIFF
--- a/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
+++ b/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.apache.commons.lang.StringUtils;
 
+import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.gatein.common.text.EntityEncoder;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -286,6 +287,11 @@ public class DocumentService implements ResourceContainer {
         for (String user : usernames) {
           ((NodeImpl) node).setPermission(user, new String[] { PermissionType.READ });
         }
+        // Add permission
+        Map<String, String[]> permissionsMap = new HashMap<String, String[]>();
+        permissionsMap.put(remoteUser, PermissionType.ALL);
+        ((NodeImpl) node).setPermissions(permissionsMap);
+
         node.save();
       }
       activityService_.setCreating(node, false);


### PR DESCRIPTION
* Maint-24357: Fix can't delete a file uploaded from chat one to one.
(cherry picked from commit 96f9e74d7afed67bcf8ea04c375c0d53d7231b83)