### PR TITLE
MAINT-26886 Fix display of chat drawer in stream page

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -7,7 +7,7 @@
       </a>
       <exo-drawer ref="chatDrawer"
                   class="chatDrawer"
-                  body-class="hide-scroll"
+                  body-classes="hide-scroll"
                   right
                   @closed="resetSelectedContact">
         <template v-if="!showSearch" slot="title">


### PR DESCRIPTION
Redefine correct property name of ExoDrawer.vue component to avoid decreasing Z-index of TopBar when opening Chat drawer.