### PR TITLE
MAINT-27226 : Add missing dependency Jquery Touch (#353)

### DIFF
--- a/application/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/application/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -60,6 +60,10 @@
             <as>$</as>
         </depends>
         <depends>
+            <module>jquery-touch</module>
+            <as>jqueryTouch</as>
+        </depends>
+        <depends>
             <module>chatCometD</module>
             <as>cCometD</as>
         </depends>


### PR DESCRIPTION
The library jQuery Touch will enable mobile interactions with Chat application like taphold, swipe etc ...

(cherry picked from commit d4ccd9beaae4139c052970e9ae9790091b70abe0)