### PR TITLE
MAINT-27437 : Scroll bar is hidden under composer in Chat Drawer (#352)

### DIFF
--- a/application/src/main/webapp/css/components/chatDrawer.less
+++ b/application/src/main/webapp/css/components/chatDrawer.less
@@ -161,7 +161,7 @@
           resize: none!important;
         }
         #chats {
-          margin-bottom: 60px;
+          margin-bottom: 101px;
           background-color:@leftContainerTextColor;
         }
         .uiIconNotification{


### PR DESCRIPTION
The composer height is hiding a part of the messages list. This fix will increase the padding to clear the hidden part.

(cherry picked from commit c986a094a4a4e788c6a480c05badc0ca71d5b497)