### PR TITLE
MAINT-27056: Make sure that the chat discussion is displayed from the first essay when clicking on chat icon in the user popover.

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -288,15 +288,24 @@ export default {
     openRoom(e) {
       const roomName = e.detail ? e.detail.name : null;
       const roomType = e.detail ? e.detail.type : null;
-      if(roomName && roomName.trim().length) {
-        chatServices.getRoomId(this.userSettings, roomName, roomType).then(rommId => {
-          this.setSelectedContact(rommId);
-        });
-      }
-      const tiptip = document.getElementById('tiptip_holder');
-      if (tiptip) {
-        tiptip.style.display = 'none';
-      }
+      
+      // make sure to re-init chat rooms before selecting a room that may be under creation.
+      chatServices.initChatSettings(this.userSettings.username, false,
+        userSettings => this.initSettings(userSettings),
+        chatRoomsData => this.initChatRooms(chatRoomsData));
+      
+      const timeOutLoading = 500;
+      window.setTimeout(() => {
+        if(roomName && roomName.trim().length) {
+          chatServices.getRoomId(this.userSettings, roomName, roomType).then(roomId => {
+            this.setSelectedContact(roomId);
+          });
+        }
+        const tiptip = document.getElementById('tiptip_holder');
+        if (tiptip) {
+          tiptip.style.display = 'none';
+        }
+      }, timeOutLoading);
     },
     showHidePlatformAdminToolbar(){
       if (location.pathname==='/portal/'.concat(eXo.env.portal.portalName).concat('/chat')) {


### PR DESCRIPTION
In some cases when a chat room is not already created between two users and that one of the users click on the chat icon in the user popover, the chat room selected is not present in the chat rooms already loaded. In order to fix this issue i made sure to reinitialize the chat rooms to make sure that the selected chat room is loaded.