### PR TITLE
MAINT-27056: Make sure that the chat discussion is displayed from the first essay when clicking on chat icon in the user popover.

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -312,7 +312,9 @@ export default {
           } else {
             this.setSelectedContact(rommId);
           }
-          this.$refs.chatDrawer.open();
+          if (this.$refs.chatDrawer) {
+            this.$refs.chatDrawer.open();
+          }
         });
       }
       const tiptip = document.getElementById('tiptip_holder');


### PR DESCRIPTION
In some cases when a chat room is not already created between two users and that one of the users click on the chat icon in the user popover, the chat room selected is not present in the chat rooms already loaded. In order to fix this issue i made sure to reinitialize the chat rooms to make sure that the selected chat room is loaded.