### PR TITLE
Fix-MAINT-37615: Make sure to dispatch event chat-external-updated after creation of chat's Vue instance.

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -116,6 +116,8 @@ export default {
     document.addEventListener(chatConstants.EVENT_GLOBAL_UNREAD_COUNT_UPDATED, this.totalUnreadMessagesUpdated);
     document.addEventListener(chatConstants.ACTION_ROOM_SHOW_PARTICIPANTS, () => this.participantsArea = true);
     document.addEventListener(chatConstants.ACTION_ROOM_OPEN_CHAT, this.openRoom);
+
+    document.dispatchEvent(new CustomEvent('chat-external-updated'));
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_DISCONNECTED, this.changeUserStatusToOffline);

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -150,6 +150,8 @@ export default {
     document.addEventListener(chatConstants.EVENT_USER_STATUS_CHANGED, this.userStatusChanged);
     document.addEventListener(chatConstants.EVENT_GLOBAL_UNREAD_COUNT_UPDATED, this.totalUnreadMessagesUpdated);
     document.addEventListener(chatConstants.ACTION_ROOM_OPEN_CHAT, this.openRoom);
+    
+    document.dispatchEvent(new CustomEvent('chat-external-updated'));
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_ROOM_UPDATED, this.roomUpdated);

--- a/application/src/main/webapp/vue-app/extension.js
+++ b/application/src/main/webapp/vue-app/extension.js
@@ -555,8 +555,6 @@ export function registerExternalComponents(componentName) {
   if (extensionRegistry) {
     extensionRegistry.registerComponent('SpaceSettings-external-component', 'space-chat-setting', externalComponentOptions);
   }
-
-  document.dispatchEvent(new CustomEvent('chat-external-updated', { detail: externalComponentOptions}));
 }
 
 export function registerDefaultExtensions(extensionType, defaultExtensions) {


### PR DESCRIPTION
At space setting's instance Vue creation the chat Vue instance is not already created, i made sure to dispatch the event of chat-external-updated after the creation of chat's Vue instance.