### PR TITLE
38986 : Missing Call button in group call

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -179,8 +179,11 @@ export default {
         this.contactOpened = false;
         chatServices.getRoomParticipantsCount(eXo.chat.userSettings, selectedContact).then( data => {
           this.selectedContact.participantsCount = data.usersCount;
-          document.dispatchEvent(new CustomEvent(chatConstants.EVENT_ROOM_SELECTION_CHANGED, {'detail' : this.selectedContact}));
         });
+        chatServices.getRoomParticipants(eXo.chat.userSettings, selectedContact).then( data => {
+          this.selectedContact.participants = data.users;
+        });
+        document.dispatchEvent(new CustomEvent(chatConstants.EVENT_ROOM_SELECTION_CHANGED, {'detail' : selectedContact}));
       }
     },
     setStatus(status) {

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
@@ -168,8 +168,8 @@ export default {
       }
     },
     calculateDisplayedContacts() {
-      const limitToLoad = 20;
-      if(this.$refs.roomParticipants) {
+      this.displayedParticipantsCount = 50;
+      if(this.$refs.roomParticipants && this.contact.type && this.contact.type !== 't') {
         const headerHeight = 70;
         const moreParticipantsTextHeight = 20;
         const participantsHeight = this.$refs.roomParticipants.clientHeight;
@@ -177,14 +177,13 @@ export default {
         const viewableParticipants = (participantsHeight - headerHeight - moreParticipantsTextHeight) / participantItemHeight;
         this.displayedParticipantsCount = Math.round(viewableParticipants);
       }
-      this.displayedParticipantsCount = this.displayedParticipantsCount ? this.displayedParticipantsCount : limitToLoad;
     },
     loadRoomParticipants(contact, onlineUsersOnly) {
       chatServices.getOnlineUsers().then(users => {
         //Get users count and remove the current user
         chatServices.getRoomParticipantsCount(eXo.chat.userSettings, contact).then( data => this.participantsCount = data.usersCount - 1);
         chatServices.getRoomParticipants(eXo.chat.userSettings, contact, users, this.displayedParticipantsCount, onlineUsersOnly).then( data => {
-          this.$emit('participants-loaded', this.participantsCount);
+          this.$emit('participants-loaded', this.participants);
           this.participants = data.users.map(user => {
             // if user attributes deleted/enabled are null update the user.
             if(user.isEnabled === 'null') {


### PR DESCRIPTION
The participants in a team room were not sent correctly to Jitsi, thus the call button did not display.
The fix sends the list to be consumed by Jitsi context creation and this will enable the call button inside team rooms.