### PR TITLE
TASK-39861 Introduce eXo Server URL parameter in Chat Standalone Deployment mode

### DIFF
--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -399,12 +399,9 @@ export function getSpaceProfileLink(space) {
 }
 
 export function sendMeetingNotes(userSettings, room, fromTimestamp, toTimestamp) {
-  const serverBase = getBaseURL();
-
   const data = {
     user: userSettings.username,
     room: room,
-    serverBase: serverBase,
     fromTimestamp: fromTimestamp,
     toTimestamp: toTimestamp
   };
@@ -420,12 +417,10 @@ export function sendMeetingNotes(userSettings, room, fromTimestamp, toTimestamp)
 }
 
 export function getMeetingNotes(userSettings, room, fromTimestamp, toTimestamp) {
-  const serverBase = getBaseURL();
   const data = {
     user: userSettings.username,
     room: room,
     portalURI: `${eXo.env.portal.context}/${eXo.env.portal.portalName}`,
-    serverBase: serverBase,
     fromTimestamp: fromTimestamp,
     toTimestamp: toTimestamp
   };

--- a/common/src/main/java/org/exoplatform/chat/utils/ChatUtils.java
+++ b/common/src/main/java/org/exoplatform/chat/utils/ChatUtils.java
@@ -10,10 +10,13 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.chat.services.ChatService;
 
 public class ChatUtils {
+
+  private static String serverBase = null;
 
   public static String getRoomId(String roomName, String user)
   {
@@ -85,6 +88,22 @@ public class ChatUtils {
     oos.writeObject( o );
     oos.close();
     return new String( Base64.encodeBase64( baos.toByteArray() ) );
+  }
+
+  public static String getServerBase() {
+    if (StringUtils.isBlank(serverBase)) {
+      serverBase = PropertyManager.getProperty(PropertyManager.PROPERTY_CHAT_SERVER_BASE);
+      if (StringUtils.isBlank(serverBase)) {
+        serverBase = System.getProperty(PropertyManager.EXO_BASE_URL);
+      }
+    }
+    return serverBase;
+  }
+
+  public static void initServerBase(String serverBaseURL) {
+    if (StringUtils.isBlank(serverBase) && StringUtils.isNotBlank(serverBaseURL)) {
+      serverBase = serverBaseURL;
+    }
   }
 
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -249,7 +249,7 @@ public class ChatServer
   @Resource
   @Route("/sendMeetingNotes")
   public Response.Content sendMeetingNotes(String user, String token, String room, String fromTimestamp,
-                                           String toTimestamp, String serverBase, ApplicationContext applicationContext, UserContext userContext) throws IOException {
+                                           String toTimestamp, ApplicationContext applicationContext, UserContext userContext) throws IOException {
     if (!tokenService.hasUserWithToken(user, token))
     {
       return Response.notFound("Petit malin !");
@@ -327,6 +327,7 @@ public class ChatServer
           senderMail = userBean.getEmail();
         }
       }
+      String serverBase = ChatUtils.getServerBase();
       String html = reportBean.getAsHtml(title, serverBase, locale);
 
       // inline images
@@ -357,7 +358,7 @@ public class ChatServer
   @Resource
   @Route("/getMeetingNotes")
   public Response.Content getMeetingNotes(String user, String token, String room, String fromTimestamp,
-                                          String toTimestamp, String serverBase, String portalURI, ApplicationContext applicationContext, UserContext userContext) throws IOException {
+                                          String toTimestamp, String portalURI, ApplicationContext applicationContext, UserContext userContext) throws IOException {
     if (!tokenService.hasUserWithToken(user, token))
     {
       return Response.notFound("Petit malin !");
@@ -417,6 +418,7 @@ public class ChatServer
 
       reportBean.fill((BasicDBList) datao.get("messages"), users);
       ArrayList<String> usersInGroup = new ArrayList<String>();
+      String serverBase = ChatUtils.getServerBase();
       wikiPageContent = reportBean.getWikiPageContent(serverBase, portalURI);
       try {
         for (UserBean userBean : users) {

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
@@ -42,8 +42,6 @@ public class ServerBootstrap {
 
   private static final Log LOG = ExoLogger.getLogger(ServerBootstrap.class.getName());
 
-  private static String    serverBase = null;
-
   private static String    serverURL = null;
 
   private static String    serviceURL = null;
@@ -217,7 +215,7 @@ public class ServerBootstrap {
     if (StringUtils.isNotBlank(serverURL) && serverURL.startsWith("http")) {
       return serverURL;
     } else {
-      serverURL = getServerBase() + getServerURI();
+      serverURL = ChatUtils.getServerBase() + getServerURI();
       return serverURL;
     }
   }
@@ -240,28 +238,19 @@ public class ServerBootstrap {
     return serverURI;
   }
 
-  public static String getServerBase() {
-    if (StringUtils.isBlank(serverBase)) {
-      serverBase = PropertyManager.getProperty(PropertyManager.PROPERTY_CHAT_SERVER_BASE);
-      if (StringUtils.isBlank(serverBase)) {
-        serverBase = System.getProperty(PropertyManager.EXO_BASE_URL);
-      }
-    }
-    return serverBase;
-  }
-
   public static void init(HttpServletRequest request) {
     if (request == null) {
       throw new IllegalArgumentException();
     }
-    if (StringUtils.isBlank(serverBase)) {
+    if (StringUtils.isBlank(ChatUtils.getServerBase())) {
       String scheme = request.getScheme();
       String serverName = request.getServerName();
       int serverPort = request.getServerPort();
-      serverBase = scheme + "://" + serverName;
+      String serverBase = scheme + "://" + serverName;
       if (serverPort != 80) {
         serverBase += ":" + serverPort;
       }
+      ChatUtils.initServerBase(serverBase);
     }
   }
 }


### PR DESCRIPTION
When sending meeting notes via email, or storing chat meeting in a wiki, the serverBase is used to retrieve data and add link from/to eXo Platform Server. This parameter shouldn't be passed from Client side (Browser) and should be parametered in Chat server side instead.