### PR TITLE
Dispatch selected contact event after request fulfiling

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -180,8 +180,8 @@ export default {
         });
         chatServices.getRoomParticipants(eXo.chat.userSettings, selectedContact).then( data => {
           this.selectedContact.participants = data.users;
+          document.dispatchEvent(new CustomEvent(chatConstants.EVENT_ROOM_SELECTION_CHANGED, {'detail' : this.selectedContact}));
         });
-        document.dispatchEvent(new CustomEvent(chatConstants.EVENT_ROOM_SELECTION_CHANGED, {'detail' : selectedContact}));
       }
     },
     setStatus(status) {

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
@@ -183,7 +183,6 @@ export default {
         //Get users count and remove the current user
         chatServices.getRoomParticipantsCount(eXo.chat.userSettings, contact).then( data => this.participantsCount = data.usersCount - 1);
         chatServices.getRoomParticipants(eXo.chat.userSettings, contact, users, this.displayedParticipantsCount, onlineUsersOnly).then( data => {
-          this.$emit('participants-loaded', this.participants);
           this.participants = data.users.map(user => {
             // if user attributes deleted/enabled are null update the user.
             if(user.isEnabled === 'null') {
@@ -200,6 +199,7 @@ export default {
             }
             return user;
           });
+          this.$emit('participants-loaded', this.participants);
           const offline = ['invisible', 'offline'];
           this.displayedParticipantsCount = this.participants.length;
           return this.participants.sort((p1, p2) => {


### PR DESCRIPTION
This PR is a followup of https://github.com/exoplatform/chat-application/pull/206 with improvements that should fix potentially unstable work of event listeners: 
- Dispatch selected contact event after request fulfiling (in resolved promise)
- Emit loaded participants after its calculation

Related task: https://community.exoplatform.com/portal/dw/tasks/taskDetail/40077