### PR TITLE
Task-40069 Task-40070 : fix access restriction on chat room for a non member

### DIFF
--- a/common/src/main/java/org/exoplatform/chat/services/ChatService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/ChatService.java
@@ -97,13 +97,16 @@ public interface ChatService
   public void setRoomName(String room, String name);
   
   public void setRoomMeetingStatus(String room, boolean start, String startTime);
-
-  /**
-   * Get rooms by name
-   * 
-   * @param teamName
-   * @return
-   */
+  
+  public boolean isMemberOfRoom(String username, String roomId);
+    
+    
+    /**
+     * Get rooms by name
+     *
+     * @param teamName
+     * @return
+     */
   public List<RoomBean> getTeamRoomsByName(String teamName);
 
   /**

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -475,7 +475,12 @@ public class ChatServer
       return Response.notFound("Petit malin !");
     }
     try {
-      chatService.deleteTeamRoom(room, user);
+      String creator = chatService.getTeamCreator(room);
+      if (!creator.equals(user)) {
+        return Response.notFound("");
+      } else {
+        chatService.deleteTeamRoom(room, user);
+      }
     } catch (Exception e) {
       LOG.log(Level.SEVERE, "Impossible to delete Team Room [" + room + "] : " + e.getMessage(), e);
       return Response.content(500, "Oups!");

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -867,10 +867,14 @@ public class ChatServer
     if (!tokenService.hasUserWithToken(user, token)) {
       return Response.notFound("Petit malin !");
     }
-    
-    chatService.setRoomMeetingStatus(room, Boolean.parseBoolean(start), startTime);
-
-    return Response.ok("Updated.");
+  
+    //only member of a room can updateRoomMeetingStatus
+    if (chatService.isMemberOfRoom(user,room)) {
+      chatService.setRoomMeetingStatus(room, Boolean.parseBoolean(start), startTime);
+      return Response.ok("Updated.");
+    } else {
+      return Response.notFound("");
+    }
   }
 
   @Resource

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
@@ -379,7 +379,7 @@ public class ChatServiceImpl implements ChatService
    * @param roomId Id of the room
    * @return true if the user is member of the room
    */
-  private boolean isMemberOfRoom(String username, String roomId) {
+  public boolean isMemberOfRoom(String username, String roomId) {
     List<String> roomMembers;
     RoomBean room = userService.getRoom(username, roomId);
     if(room == null) {

--- a/server-embedded/src/test/java/org/exoplatform/chat/server/ChatServerTest.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/server/ChatServerTest.java
@@ -372,4 +372,57 @@ public class ChatServerTest extends AbstractChatTestCase {
     assertEquals(200, usersCount.getCode());
     assertTrue("Users count should be 4",  usersCount.toString().contains("4"));
   }
-}
+  
+  
+  @Test
+  public void testDeleteRoomWhenCreator() throws Exception {
+    // Given
+    ChatServer chatServer = new ChatServer();
+    TokenService tokenService = ServiceBootstrap.getTokenService();
+    ChatService chatService = ServiceBootstrap.getChatService();
+    UserService userService = ServiceBootstrap.getUserService();
+    
+    String john = "john";
+    
+    userService.addUserFullName(john, "John Smith");
+    
+    String tokenJohn = tokenService.getToken(john);
+    tokenService.addUser(john, tokenJohn);
+  
+    String roomId = chatService.getTeamRoom("myteam", "john");
+  
+  
+    // When
+    Response.Content deleteTeamRoom = chatServer.deleteTeamRoom(john, tokenJohn, roomId);
+    // Then
+    assertNotNull(deleteTeamRoom);
+    assertEquals(200, deleteTeamRoom.getCode());
+    
+  }
+  
+  @Test
+  public void testDeleteRoomWhenNotCreator() throws Exception {
+    // Given
+    ChatServer chatServer = new ChatServer();
+    TokenService tokenService = ServiceBootstrap.getTokenService();
+    ChatService chatService = ServiceBootstrap.getChatService();
+    UserService userService = ServiceBootstrap.getUserService();
+    
+    String john = "john";
+    
+    userService.addUserFullName(john, "John Smith");
+    
+    String tokenJohn = tokenService.getToken(john);
+    tokenService.addUser(john, tokenJohn);
+    
+    String roomId = chatService.getTeamRoom("myteam", "mary");
+    
+    
+    // When
+    Response.Content deleteTeamRoom = chatServer.deleteTeamRoom(john, tokenJohn, roomId);
+    // Then
+    assertNotNull(deleteTeamRoom);
+    assertEquals(404, deleteTeamRoom.getCode());
+    
+  }
+  

--- a/server-embedded/src/test/java/org/exoplatform/chat/server/ChatServerTest.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/server/ChatServerTest.java
@@ -426,3 +426,55 @@ public class ChatServerTest extends AbstractChatTestCase {
     
   }
   
+  @Test
+  public void testUpdateRoomMeetingWhenMember() throws Exception {
+    // Given
+    ChatServer chatServer = new ChatServer();
+    TokenService tokenService = ServiceBootstrap.getTokenService();
+    ChatService chatService = ServiceBootstrap.getChatService();
+    UserService userService = ServiceBootstrap.getUserService();
+    
+    String john = "john";
+    
+    userService.addUserFullName(john, "John Smith");
+    
+    String tokenJohn = tokenService.getToken(john);
+    tokenService.addUser(john, tokenJohn);
+    
+    String roomId = chatService.getTeamRoom("myteam", "john");
+    
+    
+    // When
+    Response.Content updateRoomMeetingStatus = chatServer.updateRoomMeetingStatus(john, tokenJohn, "true", roomId, "123456789");
+    // Then
+    assertNotNull(updateRoomMeetingStatus);
+    assertEquals(200, updateRoomMeetingStatus.getCode());
+    
+  }
+  
+  @Test
+  public void testUpdateRoomMeetingWhenNotMember() throws Exception {
+    // Given
+    ChatServer chatServer = new ChatServer();
+    TokenService tokenService = ServiceBootstrap.getTokenService();
+    ChatService chatService = ServiceBootstrap.getChatService();
+    UserService userService = ServiceBootstrap.getUserService();
+    
+    String john = "john";
+    
+    userService.addUserFullName(john, "John Smith");
+    
+    String tokenJohn = tokenService.getToken(john);
+    tokenService.addUser(john, tokenJohn);
+    
+    String roomId = chatService.getTeamRoom("myteam", "mary");
+    
+    
+    // When
+    Response.Content updateRoomMeetingStatus = chatServer.updateRoomMeetingStatus(john, tokenJohn, "true", roomId, "123456789");
+    // Then
+    assertNotNull(updateRoomMeetingStatus);
+    assertEquals(404, updateRoomMeetingStatus.getCode());
+    
+  }
+}


### PR DESCRIPTION
Task-40069 : when someone call deleteTeamRoom webservice, the room seems deleted

Prior to this fix, when someone which is not the room owner can call the deleteTeamRoom web service
This function doesnt delete the room, but send an event to the interface of the owner to no mmore display the room in romm list, like if the room were deleted
This fix add a check to not send event if room is not deleted.


Task-40070 : any user can start/stop meeting in a chat room he is not member

This commit add a check to be sure that the user who make the request is member of the chat room