### PR TITLE
TASK-40264 Fix Chat Message Sanitization

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatContact.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContact.vue
@@ -6,7 +6,7 @@
     </div>
     <div class="contactDetail">
       <div :class="isActive" class="contactLabel">
-        <span v-html="escapedName" />
+        <span v-sanitized-html="escapedName" />
         <span v-if="isExternal" class="externalTagClass">{{ externalTag }}</span>
         <slot></slot>
       </div>
@@ -30,7 +30,7 @@
       <div v-if="type !='u' && !list && nbMembers > 0" class="room-number-members">
         {{ nbMembers }} {{ $t('exoplatform.chat.members') }}
       </div>
-      <div v-if="mq === 'mobile' && list && lastMessage || chatDrawerContact" :class="chatDrawerContact ? 'lastMessageDrawer last-message' : 'last-message' " v-html="lastMessage"></div>
+      <div v-sanitized-html="lastMessage" v-if="mq === 'mobile' && list && lastMessage || chatDrawerContact" :class="chatDrawerContact ? 'lastMessageDrawer last-message' : 'last-message' "></div>
     </div>
   </div>
 </template>

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
@@ -38,14 +38,14 @@
           </div>
         </div>
       </div>
-      <div v-else-if="!message.isSystem" class="message-content" v-html="messageFiltered"></div>
+      <div v-sanitized-html="messageFiltered" v-else-if="!message.isSystem" class="message-content"></div>
       <div v-else-if="messageOptionsType === chatConstants.ADD_TEAM_MESSAGE" class="message-content">
-        <span v-html="$t('exoplatform.chat.team.msg.adduser', roomAddOrDeleteI18NParams)"></span>
+        <span v-sanitized-html="$t('exoplatform.chat.team.msg.adduser', roomAddOrDeleteI18NParams)"></span>
       </div>
-      <div v-else-if="messageOptionsType === chatConstants.ROOM_MEMBER_LEFT" class="message-content" v-html="unescapeHTML($t('exoplatform.chat.team.msg.leaveroom', {0: '<b>' + message.options.fullName + '</b>'}))">
+      <div v-sanitized-html="unescapeHTML($t('exoplatform.chat.team.msg.leaveroom', {0: '<b>' + message.options.fullName + '</b>'}))" v-else-if="messageOptionsType === chatConstants.ROOM_MEMBER_LEFT" class="message-content">
       </div>
       <div v-else-if="messageOptionsType === chatConstants.REMOVE_TEAM_MESSAGE" class="message-content">
-        <span v-html="$t('exoplatform.chat.team.msg.removeuser', roomAddOrDeleteI18NParams)"></span>
+        <span v-sanitized-html="$t('exoplatform.chat.team.msg.removeuser', roomAddOrDeleteI18NParams)"></span>
       </div>
       <div v-else-if="messageOptionsType === chatConstants.EVENT_MESSAGE" class="message-content">
         <b>{{ message.options.summary }}</b>
@@ -61,8 +61,7 @@
           {{ message.options.location }}
         </div>
       </div>
-      <div v-else-if="messageOptionsType === chatConstants.LINK_MESSAGE" class="message-content">
-        <a :href="message.options.link" target="_blank">{{ message.options.link }}</a>
+      <div v-autolinker="message.options.link" v-else-if="messageOptionsType === chatConstants.LINK_MESSAGE" class="message-content">
       </div>
       <div v-else-if="(messageOptionsType === chatConstants.RAISE_HAND || messageOptionsType === chatConstants.QUESTION_MESSAGE)" class="message-content">
         <b>{{ messageContent }}</b>
@@ -95,7 +94,7 @@
           <a href="#" target="_blank">{{ $t('exoplatform.chat.open.wiki') }}</a>.
         </div>
       </div>
-      <div v-else-if="isSpecificMessageType" class="message-content" v-html="specificMessageContent">
+      <div v-sanitized-html="specificMessageContent" v-else-if="isSpecificMessageType" class="message-content">
       </div>
       <div class="message-description">
         <i v-if="isEditedMessage" class="uiIconChatEdit"></i>
@@ -133,7 +132,7 @@
     <exo-chat-modal v-show="showConfirmModal" :title="$t(confirmTitle)" @modal-closed="showConfirmModal=false">
       <div class="modal-body">
         <p>
-          <span id="team-delete-window-chat-name" class="confirmationIcon" v-html="unescapeHTML($t(confirmMessage))">
+          <span v-sanitized-html="unescapeHTML($t(confirmMessage))" id="team-delete-window-chat-name" class="confirmationIcon">
           </span>
         </p>
       </div>

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageList.vue
@@ -12,7 +12,16 @@
     </div>
     <exo-chat-message-composer :contact="contact" :mini-chat="miniChat" :user-settings="userSettings" @message-written="messageWritten"></exo-chat-message-composer>
     <exo-chat-modal v-if="!miniChat" v-show="showEditMessageModal" :title="$t('exoplatform.chat.msg.edit')" modal-class="edit-message-modal" @modal-closed="closeModal">
-      <exo-content-editable id="editMessageComposerArea" ref="editMessageComposerArea" v-model="messageToEdit.msg" name="editMessageComposerArea" autofocus @keydown.enter="preventDefault" @keypress.enter="preventDefault" @keyup.enter="saveEditMessage"></exo-content-editable>
+      <exo-content-editable
+        v-if="showEditMessageModal"
+        id="editMessageComposerArea"
+        ref="editMessageComposerArea"
+        v-model="messageToEdit.msg"
+        name="editMessageComposerArea"
+        autofocus
+        @keydown.enter="preventDefault"
+        @keypress.enter="preventDefault"
+        @keyup.enter="saveEditMessage" />
       <div class="uiAction uiActionBorder">
         <div class="btn btn-primary" @click="saveEditMessage(false)">{{ $t('exoplatform.chat.save') }}</div>
         <div class="btn" @click="closeModal">{{ $t('exoplatform.chat.cancel') }}</div>

--- a/application/src/main/webapp/vue-app/components/ExoMiniChatNotifDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoMiniChatNotifDetail.vue
@@ -7,7 +7,7 @@
       <div class="content">
         <span class="name text-link" href="#">{{ notif.fromFullName }}</span>
         <i v-if="messageClass && messageClass.length" :class="messageClass"></i>
-        <div class="text" v-html="messageContent" />
+        <div v-sanitized-html="messageContent" class="text"></div>
       </div>
       <div class="gray-box">
         <div class="timestamp time">

--- a/application/src/main/webapp/vue-app/components/modal/ExoContentEditable.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoContentEditable.vue
@@ -1,21 +1,18 @@
 <template>
-  <div v-once :value="value" contenteditable="true" @input="$emit(`input`, $event.target.innerHTML)" v-html="value"></div>
+  <div
+    v-sanitized-html="value"
+    v-once
+    contenteditable="true"
+    @input="$emit(`input`, $event.target.innerHTML);">
+  </div>
 </template>
 
 <script>
 export default {
   props: {
-    value  : {
-      type: Object,
+    value: {
+      type: String,
       default: null
-    }
-  },
-  watch: {
-    value: function (newValue) {
-      if (document.activeElement === this.$el) {
-        return;
-      }
-      this.$el.innerHTML = newValue;
     }
   },
 };

--- a/application/src/test/globals.js
+++ b/application/src/test/globals.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import Vue from 'vue';
 import {addCaretJQueryExtension} from '../main/webapp/js/lib/text-caret';
 
 global.extensionRegistry = require('./libs/extensionRegistry.js');
@@ -10,6 +11,9 @@ $.fn.extend({
   //mock userPopup extension
   userPopup() {}
 });
+
+Vue.directive('sanitized-html', (el, binding) => el.innerHTML = binding.value);
+Vue.directive('autolinker', (el, binding) => el.innerHTML = binding.value);
 
 global.eXo = {
   env: {


### PR DESCRIPTION
This fix will use [newly introduced JS library](https://github.com/Meeds-io/commons/pull/93) to purify Chat messages.
The solution consists to :
1. Use `v-sanitized-html` instead of `v-html` in order to do HTML sanitization and to prevent XSS attacks
2. Use `v-autolinker` on links sent by user  in order to do HTML sanitization and to prevent XSS attacks