### PR TITLE
TASK-26741: added the notification number update when a message is sent

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -140,9 +140,17 @@ export default {
       }
     }
   },
+  watch: {
+    totalUnreadMsg() {
+      chatServices.updateTotalUnread(this.totalUnreadMsg);
+    },
+  },
   created() {
     chatServices.getUserSettings(this.userSettings.username).then(userSettings => {
       this.initSettings(userSettings);
+    });
+    chatServices.getNotReadMessages(this.userSettings).then(data => {
+      this.totalUnreadMsg = data.total;
     });
     document.addEventListener(chatConstants.EVENT_ROOM_UPDATED, this.roomUpdated);
     document.addEventListener(chatConstants.EVENT_LOGGED_OUT, this.userLoggedout);


### PR DESCRIPTION
Before this fix , the number of messages received doesn't appear int the title of the page unless the chat drawer is opened and even when a message is read by a user the update in the title  is not taking place unless the page is reloaded. So i added a watch method on the totalUnreadMessag proprety an created a new method named openchat that initialise the chat configuration and make the update on the launch. 