### PR TITLE
41080 : fix Chat Drawer when initiating new discussions

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -341,19 +341,11 @@ export default {
       const roomName = e.detail ? e.detail.name : null;
       const roomType = e.detail ? e.detail.type : null;
       if(roomName && roomName.trim().length) {
-        this.$refs.chatDrawer.startLoading();
-        chatServices.getRoomId(this.userSettings, roomName, roomType).then(rommId => {
-          const selectedContact = this.contactList.find(contact => contact.room === rommId || contact.user === rommId);
-          if ( !selectedContact ) {
-            this.refreshContacts(false);
-            this.selectedContact = rommId;
-          } else {
-            this.setSelectedContact(rommId);
-          }
-          if (this.$refs.chatDrawer) {
-            this.$refs.chatDrawer.open();
-          }
-        }).finally(this.$refs.chatDrawer.endLoading);
+        chatServices.getRoomId(this.userSettings, roomName, roomType).then(roomId =>
+          chatServices.getRoomDetail(this.userSettings, roomId).then( room => {
+            this.openDrawer();
+            this.setSelectedContact(room);
+          }));
       }
       const tiptip = document.getElementById('tiptip_holder');
       if (tiptip) {


### PR DESCRIPTION
When we chat with a new user, the discussion is created asynchronously. The room is not always added to the list of contacts.
The fix will reload the list of contacts and will make sure to get the new discussion once created to add it to the list of contacts once the drawer is initiated correctly.