### PR TITLE
TASK-43200 Enhance Chat extension activation for spaces

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="contact && Object.keys(contact).length !== 0 && (contact.isEnabledUser === 'true' || contact.isEnabledUser === 'null')" :class="{'is-apps-closed': appsClosed}" class="chat-message-composer">
+  <div v-if="contact && Object.keys(contact).length !== 0 && (contact.isEnabledUser === 'true' || contact.isEnabledRoom === 'true')" :class="{'is-apps-closed': appsClosed}" class="chat-message-composer">
     <div v-if="!miniChat">
       <div v-show="!appsClosed" class="apps-container justify-center">
         <div v-for="app in composerApplications" :key="app.key" class="apps-item" @click="openAppModal(app)">

--- a/application/src/main/webapp/vue-app/extension.js
+++ b/application/src/main/webapp/vue-app/extension.js
@@ -1,6 +1,5 @@
 import {chatConstants} from './chatConstants.js';
 import {initTiptip} from './tiptip.js';
-import * as chatServices from './chatServices.js';
 
 export const ECMS_EVENT_COMPOSER_APP = [{
   key: 'file',
@@ -464,21 +463,11 @@ export const DEFAULT_MESSAGE_ACTIONS = [
 
 export function registerExternalExtensions(chatTitle) {
   const profileExtensionAction = {
+    id: 'profile-chat',
     title: chatTitle,
     icon: 'uiIconBannerChat',
     order: 10,
-    enabled: async (profile) => {
-      // check if the space's chat is enabled
-      if (profile.hasOwnProperty('groupId')) {
-        return await chatServices.getUserSettings()
-          .then(userSettings => {
-            return chatServices.isRoomEnabled(userSettings, profile.id)
-              .then(value => value === 'true');
-          }).then(value => value);
-      }
-      // if it's a user profile
-      return true;
-    },
+    enabled: () => true,
     click: (profile) => {
       const chatType = profile.groupId ? 'space-id' : 'username';
       const chatRoomName = profile.prettyName ? profile.id : profile.username;


### PR DESCRIPTION
This modification is related to Meeds-io/gatein-portal#197

Prior to this change, a lot of HTTP requests are sent at the same time to the server when displaying a list of spaces.
By making this change, the space chat feature enablement will be checked only when displaying details of room by hiding message composer when disabled.