### PR TITLE
 43172 : Prevent full loading of all Chat contacts by pagination

### DIFF
--- a/application/src/main/webapp/vue-app/chatConstants.js
+++ b/application/src/main/webapp/vue-app/chatConstants.js
@@ -80,6 +80,7 @@ export const chatConstants = {
   ACTION_ROOM_SHOW_PARTICIPANTS: 'exo-chat-setting-showParticipants-requested',
   ACTION_APPS_CLOSE: 'exo-chat-apps-close-requested',
   ACTION_ROOM_OPEN_CHAT: 'exo-chat-room-open-requested',
+  ACTION_FILTER_ROOM_TYPE: 'exo-chat-room-filter-changed',
   EVENT_CONNECTED: 'exo-chat-connected',
   EVENT_DISCONNECTED: 'exo-chat-disconnected',
   EVENT_RECONNECTED: 'exo-chat-reconnected',

--- a/application/src/main/webapp/vue-app/chatConstants.js
+++ b/application/src/main/webapp/vue-app/chatConstants.js
@@ -101,5 +101,7 @@ export const chatConstants = {
   EVENT_ROOM_UPDATED: 'exo-chat-room-updated',
   EVENT_ROOM_SELECTION_CHANGED: 'exo-chat-selected-contact-changed',
   EVENT_USER_SETTINGS_LOADED: 'exo-chat-settings-loaded',
-  EVENT_USER_STATUS_CHANGED: 'exo-chat-user-status-changed'
+  EVENT_USER_STATUS_CHANGED: 'exo-chat-user-status-changed',
+  DEFAULT_OFFSET: 0,
+  DEFAULT_USER_LIMIT: 20
 };

--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -52,8 +52,10 @@ export function initChatSettings(username, isMiniChat, userSettingsLoadedCallbac
       //mini chat only need fetching notifications
       getNotReadMessages(settings).then(notifications => chatRoomsLoadedCallback(notifications));
     } else {
+      // Get the selected room type filter
+      const roomTypeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
       // fetch online users then fetch chat rooms
-      getOnlineUsers().then(users => getUserChatRooms(settings, users)).then(data => chatRoomsLoadedCallback(data));
+      getOnlineUsers().then(users => getUserChatRooms(settings, users, '', roomTypeFilter)).then(data => chatRoomsLoadedCallback(data));
     }
 
     document.addEventListener(chatConstants.EVENT_ROOM_SELECTION_CHANGED, (e) => {
@@ -197,8 +199,9 @@ export function getChatRooms(userSettings, onlineUsers, filter, limit) {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());
 }
-export function getUserChatRooms(userSettings, onlineUsers, filter, offset, limit) {
-  if (!limit) {
+
+export function getUserChatRooms(userSettings, onlineUsers, filter, roomType, offset, limit) {
+  if(!limit) {
     limit = chatConstants.ROOMS_PER_PAGE;
   }
   if(!offset) {
@@ -207,7 +210,10 @@ export function getUserChatRooms(userSettings, onlineUsers, filter, offset, limi
   if (!filter) {
     filter = '';
   }
-  return fetch(`${chatConstants.CHAT_SERVER_API}userRooms?user=${userSettings.username}&onlineUsers=${onlineUsers}&filter=${filter}&offset=${offset}&limit=${limit}&timestamp=${new Date().getTime()}`, {
+  if(!roomType || roomType === 'All') {
+    roomType = '';
+  }
+  return fetch(`${chatConstants.CHAT_SERVER_API}userRooms?user=${userSettings.username}&onlineUsers=${onlineUsers}&filter=${filter}&offset=${offset}&limit=${limit}&roomType=${roomType}&timestamp=${new Date().getTime()}`, {
     headers: {
       'Authorization': `Bearer ${userSettings.token}`
     }}).then(resp =>  resp.json());

--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -201,16 +201,16 @@ export function getChatRooms(userSettings, onlineUsers, filter, limit) {
 }
 
 export function getUserChatRooms(userSettings, onlineUsers, filter, roomType, offset, limit) {
-  if(!limit) {
+  if (!limit) {
     limit = chatConstants.ROOMS_PER_PAGE;
   }
-  if(!offset) {
+  if (!offset) {
     offset = chatConstants.DEFAULT_OFFSET;
   }
   if (!filter) {
     filter = '';
   }
-  if(!roomType || roomType === 'All') {
+  if (!roomType || roomType === 'All') {
     roomType = '';
   }
   return fetch(`${chatConstants.CHAT_SERVER_API}userRooms?user=${userSettings.username}&onlineUsers=${onlineUsers}&filter=${filter}&offset=${offset}&limit=${limit}&roomType=${roomType}&timestamp=${new Date().getTime()}`, {
@@ -220,7 +220,7 @@ export function getUserChatRooms(userSettings, onlineUsers, filter, roomType, of
 }
 
 export function getRoomParticipants(userSettings, room, onlineUsers, limit, onlineUsersOnly) {
-  if(!limit && isNaN(limit)) {
+  if (!limit && isNaN(limit)) {
     limit = chatConstants.DEFAULT_USER_LIMIT;
   }
   onlineUsersOnly = onlineUsersOnly && onlineUsersOnly === true;
@@ -333,7 +333,7 @@ export function loadNotificationSettings(settings) {
 }
 
 export function getChatUsers(userSettings, filter, limit) {
-  if(!limit) {
+  if (!limit) {
     limit = chatConstants.DEFAULT_USER_LIMIT;
   }
   return fetch(`${chatConstants.CHAT_SERVER_API}users?user=${userSettings.username}&filter=${filter}&limit=${limit}`, {

--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -3,8 +3,7 @@ import * as chatWebStorage from './chatWebStorage';
 import * as chatWebSocket from './chatWebSocket';
 import * as desktopNotification from './desktopNotification';
 
-const DEFAULT_OFFSET = 0;
-const DEFAULT_USER_LIMIT = 20;
+
 const DEFAULT_HTTP_PORT = 80;
 const REATTEMPT_INIT_PERIOD = 1000;
 const MAX_UNREAD_NUMBER = 99;
@@ -202,8 +201,8 @@ export function getUserChatRooms(userSettings, onlineUsers, filter, offset, limi
   if (!limit) {
     limit = chatConstants.ROOMS_PER_PAGE;
   }
-  if (!offset) {
-    offset = DEFAULT_OFFSET;
+  if(!offset) {
+    offset = chatConstants.DEFAULT_OFFSET;
   }
   if (!filter) {
     filter = '';
@@ -215,8 +214,8 @@ export function getUserChatRooms(userSettings, onlineUsers, filter, offset, limi
 }
 
 export function getRoomParticipants(userSettings, room, onlineUsers, limit, onlineUsersOnly) {
-  if (!limit && isNaN(limit)) {
-    limit = DEFAULT_USER_LIMIT;
+  if(!limit && isNaN(limit)) {
+    limit = chatConstants.DEFAULT_USER_LIMIT;
   }
   onlineUsersOnly = onlineUsersOnly && onlineUsersOnly === true;
 
@@ -328,8 +327,8 @@ export function loadNotificationSettings(settings) {
 }
 
 export function getChatUsers(userSettings, filter, limit) {
-  if (!limit) {
-    limit = DEFAULT_USER_LIMIT;
+  if(!limit) {
+    limit = chatConstants.DEFAULT_USER_LIMIT;
   }
   return fetch(`${chatConstants.CHAT_SERVER_API}users?user=${userSettings.username}&filter=${filter}&limit=${limit}`, {
     headers: {

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -32,8 +32,9 @@
         :selected="selectedContact"
         :loading-contacts="loadingContacts"
         @open-side-menu="sideMenuArea = !sideMenuArea"
-        @load-more-contacts="loadMoreContacts"
+        @load-more-contacts="changeFilter"
         @search-contact="searchContacts"
+        @change-filter-type="changeFilter"
         @contact-selected="setSelectedContact"
         @refresh-contacts="refreshContacts($event)" />
     </div>
@@ -298,6 +299,7 @@ export default {
       chatServices.getOnlineUsers().then(users => {
         chatServices.getUserChatRooms(this.userSettings, users, '', nbPages * chatConstants.DEFAULT_USER_LIMIT).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms, true);
+          this.contactsSize = chatRoomsData.roomsCount;
           this.loadingContacts = false;
         });
       });
@@ -307,6 +309,24 @@ export default {
       chatServices.getOnlineUsers().then(users => {
         chatServices.getUserChatRooms(this.userSettings, users, term).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms);
+          this.contactsSize = chatRoomsData.roomsCount;
+          this.loadingContacts = false;
+        });
+      });
+    },
+    changeFilter(term, filter, pageNumber) {
+      let offset = 0;
+      if(filter === 'All') {
+        filter = '';
+      }
+      if(pageNumber) {
+        offset = pageNumber * chatConstants.ROOMS_PER_PAGE;
+      }
+      this.loadingContacts = true;
+      chatServices.getOnlineUsers().then(users => {
+        chatServices.getUserChatRooms(this.userSettings, users, term, filter, offset).then(chatRoomsData => {
+          this.addRooms(chatRoomsData.rooms, pageNumber);
+          this.contactsSize = chatRoomsData.roomsCount;
           this.loadingContacts = false;
         });
       });

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -280,7 +280,7 @@ export default {
       }
     },
     addRooms(rooms, append) {
-      if(!append) {
+      if (!append) {
         this.contactList = [];
       }
       const contacts = this.contactList.slice(0);
@@ -316,10 +316,10 @@ export default {
     },
     changeFilter(term, filter, pageNumber) {
       let offset = 0;
-      if(filter === 'All') {
+      if (filter === 'All') {
         filter = '';
       }
-      if(pageNumber) {
+      if (pageNumber) {
         offset = pageNumber * chatConstants.ROOMS_PER_PAGE;
       }
       this.loadingContacts = true;

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -28,6 +28,7 @@
       <exo-chat-contact-list
         v-if="ap"
         :contacts="contactList"
+        :contacts-size="contactsSize"
         :selected="selectedContact"
         :loading-contacts="loadingContacts"
         @open-side-menu="sideMenuArea = !sideMenuArea"
@@ -109,6 +110,7 @@ export default {
   data() {
     return {
       contactList: [],
+      contactsSize: 0,
       /**
        * chatPage: {String}
        * cometdToken: {String}
@@ -192,6 +194,7 @@ export default {
       this.loadingContacts = false;
       
       this.addRooms(chatRoomsData.rooms);
+      this.contactsSize = chatRoomsData.roomsCount;
 
       if (this.mq !== 'mobile') {
         const selectedRoom = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_LAST_SELECTED_ROOM);
@@ -275,8 +278,10 @@ export default {
         this.userSettings.status = this.userSettings.originalStatus;
       }
     },
-    addRooms(rooms) {
-      this.contactList = [];
+    addRooms(rooms, append) {
+      if(!append) {
+        this.contactList = [];
+      }
       const contacts = this.contactList.slice(0);
       rooms = rooms.filter(contact => contact.fullName
         && contact.fullName.trim().length > 0
@@ -291,8 +296,8 @@ export default {
     loadMoreContacts(nbPages) {
       this.loadingContacts = true;
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getChatRooms(this.userSettings, users, '', nbPages).then(chatRoomsData => {
-          this.addRooms(chatRoomsData.rooms);
+        chatServices.getUserChatRooms(this.userSettings, users, '', nbPages * chatConstants.DEFAULT_USER_LIMIT).then(chatRoomsData => {
+          this.addRooms(chatRoomsData.rooms, true);
           this.loadingContacts = false;
         });
       });
@@ -300,7 +305,7 @@ export default {
     searchContacts(term) {
       this.loadingContacts = true;
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getChatRooms(this.userSettings, users, term).then(chatRoomsData => {
+        chatServices.getUserChatRooms(this.userSettings, users, term).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms);
           this.loadingContacts = false;
         });
@@ -308,7 +313,7 @@ export default {
     },
     refreshContacts(keepSelectedContact) {
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getChatRooms(this.userSettings, users).then(chatRoomsData => {
+        chatServices.getUserChatRooms(this.userSettings, users).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms);
           if (!keepSelectedContact && this.selectedContact) {
             const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user);

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -320,7 +320,7 @@ export default {
       this.$emit('change-filter-type', this.searchTerm, this.typeFilter, this.nbrePages = 0);
     },
     searchWord(newValue) {
-      if(newValue) {
+      if (newValue) {
         this.searchTerm = newValue;
         chatServices.getOnlineUsers().then(users => {
           chatServices.getUserChatRooms(eXo.chat.userSettings, users, this.searchTerm).then(chatRoomsData => {

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -282,7 +282,8 @@ export default {
       filterMenuClosed: true,
       contactsToDisplay: [],
       inactive: this.$t('exoplatform.chat.inactive'),
-      external: this.$t('exoplatform.chat.external')
+      external: this.$t('exoplatform.chat.external'),
+      nbrePages: 0
     };
   },
   computed: {
@@ -335,22 +336,7 @@ export default {
       return sortedContacts.slice(0, this.contactsToDisplay.length);
     },
     hasMoreContacts() {
-      if (this.searchTerm.trim().length) {
-        return false;
-      }
-      // All Rooms and spaces are loaded with the first call, only users are paginated
-      switch (this.typeFilter) {
-      case 'People':
-        return this.usersCount >= this.contactsToDisplay.length;
-      case 'Rooms':
-        return this.roomsCount > this.contactsToDisplay.length;
-      case 'Spaces':
-        return this.spacesCount > this.contactsToDisplay.length;
-      case 'Favorites':
-        return this.favoritesCount > this.contactsToDisplay.length;
-      default:
-        return this.contactsSize > this.contactsToDisplay.length;
-      }
+      return this.contactsSize > this.contacts.length;
     }
   },
   watch: {
@@ -364,7 +350,8 @@ export default {
       if (newValue) {
         chatServices.getOnlineUsers().then(users => {
           chatServices.getChatRooms(eXo.chat.userSettings, users).then(chatRoomsData => {
-            this.contactsToDisplay = chatRoomsData.rooms;
+            this.contacts = chatRoomsData.rooms;
+            this.contactsSize = chatRoomsData.roomsCount;
           });
         });
       }
@@ -695,8 +682,7 @@ export default {
       return foundContact;
     },
     loadMore() {
-      this.totalEntriesToLoad = this.contactsToDisplay.length;
-      this.$emit('load-more-contacts', this.totalEntriesToLoad);
+      this.$emit('load-more-contacts', ++this.nbrePages);
     },
     favoriteTooltip(contact) {
       return contact.isFavorite === true ? this.$t('exoplatform.chat.remove.favorites') : this.$t('exoplatform.chat.add.favorites');

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -261,9 +261,9 @@ export default {
       sortFilterMobile: null,
       filterByType: {
         'All': this.$t('exoplatform.chat.contact.all'),
-        'People': this.$t('exoplatform.chat.people'),
-        'Rooms': this.$t('exoplatform.chat.teams'),
-        'Spaces': this.$t('exoplatform.chat.spaces'),
+        'u': this.$t('exoplatform.chat.people'),
+        't': this.$t('exoplatform.chat.teams'),
+        's': this.$t('exoplatform.chat.spaces'),
         'Favorites': this.$t('exoplatform.chat.favorites')
       },
       typeFilter: chatConstants.TYPE_FILTER_DEFAULT,
@@ -290,36 +290,8 @@ export default {
     statusStyle() {
       return this.contactStatus === 'inline' ? 'user-available' : 'user-invisible';
     },
-    usersCount() {
-      return this.contactsToDisplay.filter(contact => contact.type === 'u').length;
-    },
-    roomsCount() {
-      return this.contactsToDisplay.filter(contact => contact.type === 't').length;
-    },
-    spacesCount() {
-      return this.contactsToDisplay.filter(contact => contact.type === 's').length;
-    },
-    favoritesCount() {
-      return this.contactsToDisplay.filter(contact => contact.isFavorite).length;
-    },
     filteredContacts: function() {
-      let sortedContacts = this.contactsToDisplay.slice(0).filter(contact => (contact.room || contact.user) && contact.fullName);
-      // this code used to search in whole Chat app, because the search uses a criteria (typeFilter)
-      if (this.typeFilter !== 'All' && !this.drawerStatus) {
-        sortedContacts = sortedContacts.filter(contact =>
-          this.typeFilter === 'People' && contact.type === 'u'
-          || this.typeFilter === 'Rooms' && contact.type === 't'
-          || this.typeFilter === 'Spaces' && contact.type === 's'
-          || this.typeFilter === 'Favorites' && contact.isFavorite
-        );
-      }
-      if (this.searchTerm && this.searchTerm.trim().length) {
-        sortedContacts = sortedContacts.filter(contact => this.normalizeText(contact.fullName.toLowerCase()).indexOf(this.normalizeText(this.searchTerm.toLowerCase())) >= 0);
-      }
-      // for the drawer chat, the search doesn't use a criteria (search filter) so it searches in all contacts
-      if (this.searchWord && this.searchWord.trim().length) {
-        sortedContacts = sortedContacts.filter(contact => this.normalizeText(contact.fullName.toLowerCase()).indexOf(this.normalizeText(this.searchWord.toLowerCase())) >= 0);
-      }
+      const sortedContacts = this.contacts.slice(0).filter(contact => (contact.room || contact.user) && contact.fullName);
       if (this.sortFilter === 'Unread') {
         sortedContacts.sort(function(a, b){
           const unreadTotal = b.unreadTotal - a.unreadTotal;
@@ -344,12 +316,14 @@ export default {
       this.contactsToDisplay = this.contacts.slice();
     },
     searchTerm(value) {
-      this.$emit('search-contact', value);
+      this.searchTerm = value;
+      this.$emit('change-filter-type', this.searchTerm, this.typeFilter, this.nbrePages = 0);
     },
     searchWord(newValue) {
-      if (newValue) {
+      if(newValue) {
+        this.searchTerm = newValue;
         chatServices.getOnlineUsers().then(users => {
-          chatServices.getChatRooms(eXo.chat.userSettings, users).then(chatRoomsData => {
+          chatServices.getUserChatRooms(eXo.chat.userSettings, users, this.searchTerm).then(chatRoomsData => {
             this.contacts = chatRoomsData.rooms;
             this.contactsSize = chatRoomsData.roomsCount;
           });
@@ -401,7 +375,6 @@ export default {
     document.removeEventListener(chatConstants.EVENT_MESSAGE_NOT_SENT, this.messageNotSent);
   },
   methods: {
-
     normalizeText(s) {
       return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     },
@@ -449,6 +422,7 @@ export default {
     selectTypeFilter(filter) {
       this.typeFilter = filter;
       chatWebStorage.setStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, this.typeFilter);
+      this.$emit('change-filter-type', this.searchTerm, this.typeFilter, this.nbrePages = 0);
     },
     initFilterMobile() {
       this.typeFilterMobile = this.typeFilter;
@@ -682,7 +656,8 @@ export default {
       return foundContact;
     },
     loadMore() {
-      this.$emit('load-more-contacts', ++this.nbrePages);
+      this.nbrePages++;
+      this.$emit('load-more-contacts', this.searchTerm, this.typeFilter, this.nbrePages);
     },
     favoriteTooltip(contact) {
       return contact.isFavorite === true ? this.$t('exoplatform.chat.remove.favorites') : this.$t('exoplatform.chat.add.favorites');

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -347,10 +347,10 @@ export default {
     },
     loadMoreContacts(term, filter, pageNumber) {
       let offset = 0;
-      if(filter === 'All') {
+      if (filter === 'All') {
         filter = '';
       }
-      if(pageNumber) {
+      if (pageNumber) {
         offset = pageNumber * chatConstants.ROOMS_PER_PAGE;
       }
       this.loadingContacts = true;

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -345,11 +345,18 @@ export default {
       const totalUnreadMsg = Math.abs(chatRoomsData.unreadOffline) + Math.abs(chatRoomsData.unreadOnline) + Math.abs(chatRoomsData.unreadSpaces) + Math.abs(chatRoomsData.unreadTeams);
       chatServices.updateTotalUnread(totalUnreadMsg);
     },
-    loadMoreContacts(nbPages) {
+    loadMoreContacts(term, filter, pageNumber) {
+      let offset = 0;
+      if(filter === 'All') {
+        filter = '';
+      }
+      if(pageNumber) {
+        offset = pageNumber * chatConstants.ROOMS_PER_PAGE;
+      }
       this.loadingContacts = true;
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getUserChatRooms(this.userSettings, users, '', nbPages * chatConstants.DEFAULT_USER_LIMIT).then(chatRoomsData => {
-          this.addRooms(chatRoomsData.rooms);
+        chatServices.getUserChatRooms(this.userSettings, users, term, filter, offset).then(chatRoomsData => {
+          this.addRooms(chatRoomsData.rooms, pageNumber);
           this.contactsSize = chatRoomsData.roomsCount;
           this.loadingContacts = false;
         });
@@ -395,7 +402,7 @@ export default {
     searchContacts(term) {
       this.loadingContacts = true;
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getChatRooms(this.userSettings, users, term).then(chatRoomsData => {
+        chatServices.getUserChatRooms(this.userSettings, users, term).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms);
           this.contactsSize = chatRoomsData.roomsCount;
           this.loadingContacts = false;

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -348,7 +348,7 @@ export default {
     loadMoreContacts(nbPages) {
       this.loadingContacts = true;
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getUserChatRooms(this.userSettings, users, '', nbPages).then(chatRoomsData => {
+        chatServices.getUserChatRooms(this.userSettings, users, '', nbPages * chatConstants.DEFAULT_USER_LIMIT).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms);
           this.contactsSize = chatRoomsData.roomsCount;
           this.loadingContacts = false;

--- a/common/src/main/java/org/exoplatform/chat/services/ChatService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/ChatService.java
@@ -132,6 +132,8 @@ public interface ChatService
 
   public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService);
 
+  public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService, String roomType);
+
   public int getNumberOfRooms();
 
   public int getNumberOfMessages();

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -116,7 +116,7 @@ public class ChatServer
 
   @Resource
   @Route("/userRooms")
-  public Response.Content getUserRooms(String user, String onlineUsers, String token, String filter, String offset, String limit)
+  public Response.Content getUserRooms(String user, String onlineUsers, String token, String filter, String offset, String limit, String roomType)
   {
     if (!tokenService.hasUserWithToken(user, token))
     {
@@ -143,7 +143,7 @@ public class ChatServer
     List<String> limitUsers = Arrays.asList(onlineUsers.split(","));
 
     RoomsBean roomsBean = chatService.getUserRooms(user, limitUsers, filter, offsetValue, limitValue,
-            notificationService, tokenService);
+            notificationService, tokenService, roomType);
 
 
     return Response.ok(roomsBean.roomsToJSON()).withMimeType("application/json").withHeader

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatDataStorage.java
@@ -128,4 +128,10 @@ public interface ChatDataStorage
    * @return RoomsBean the list of rooms in a single Object
    */
   public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService);
+
+  /**
+   * Get all the rooms of the with pagination
+   * @return RoomsBean the list of rooms in a single Object
+   */
+  public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService, String roomType);
   }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
@@ -378,6 +378,9 @@ public class ChatServiceImpl implements ChatService
   public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService) {
     return chatStorage.getUserRooms(user,onlineUsers, filter, offset, limit, notificationService, tokenService);
   }
+  public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService, String roomType) {
+    return chatStorage.getUserRooms(user,onlineUsers, filter, offset, limit, notificationService, tokenService, roomType);
+  }
 
   public int getNumberOfRooms()
   {

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import java.util.regex.Pattern;
 
 import static org.exoplatform.chat.services.ChatService.*;
+import static org.exoplatform.chat.services.UserDataStorage.STATUS_OFFLINE;
 import static org.exoplatform.chat.services.mongodb.UserMongoDataStorage.M_USERS_COLLECTION;
 
 @Named("chatStorage")
@@ -960,7 +961,13 @@ public class ChatMongoDataStorage implements ChatDataStorage {
           roomBean.setFullName(targetUserBean.getFullname());
           roomBean.setFavorite(userBean.isFavorite(roomBean.getRoom()));
           roomBean.setEnabledUser(targetUserBean.isEnabledUser());
-          roomBean.setAvailableUser(onlineUsers.contains(targetUser));
+          if(onlineUsers.contains(targetUser)) {
+            roomBean.setAvailableUser(true);
+            roomBean.setStatus(userDataStorage.getStatus(targetUser));
+          } else {
+            roomBean.setAvailableUser(false);
+            roomBean.setStatus(STATUS_OFFLINE);
+          }
           roomBean.setUser(targetUser);
           roomBean.setType(TYPE_ROOM_USER);
         }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
@@ -830,6 +830,7 @@ public class ChatMongoDataStorage implements ChatDataStorage {
 
   }
 
+
   /**
    * This will load all user rooms with pagination
    * @param user the user for whom roomw will be loaded
@@ -842,6 +843,22 @@ public class ChatMongoDataStorage implements ChatDataStorage {
    * @return RoomsBean containing all rooms with unread messages
    */
   public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService) {
+    return getUserRooms(user, onlineUsers, filter, offset, limit, notificationService, tokenService, null);
+  }
+
+  /**
+   * This will load all user rooms with pagination
+   * @param user the user for whom roomw will be loaded
+   * @param onlineUsers list of online users
+   * @param filter the filter used to filter rooms
+   * @param offset the current offset
+   * @param limit the limit of rooms
+   * @param notificationService service storing rooms notifications
+   * @param tokenService service storing tokens
+   * @param roomType type of the room : u for one to one , t for team room or s for space rooms
+   * @return RoomsBean containing all rooms with unread messages
+   */
+  public RoomsBean getUserRooms(String user, List<String> onlineUsers, String filter, int offset, int limit, NotificationService notificationService, TokenService tokenService, String roomType) {
     List<RoomBean> rooms = new ArrayList<>();;
     int unreadOffline = 0, unreadOnline = 0, unreadSpaces = 0, unreadTeams = 0, roomsCount = 0;
     UserBean userBean = userDataStorage.getUser(user, true);
@@ -855,22 +872,28 @@ public class ChatMongoDataStorage implements ChatDataStorage {
       List<BasicDBObject> andList = new ArrayList<>();
       List<BasicDBObject> orList = new ArrayList<>();
       DBObject doc = cursor.next();
-      BasicDBList spaces = (BasicDBList)doc.get("spaces");
-      BasicDBList teams = (BasicDBList)doc.get("teams");
-      if(spaces != null) {
-        for (Object room : spaces) {
-          roomsIds.add((String) room);
+      if(StringUtils.isBlank(roomType) || TYPE_ROOM_SPACE.equals(roomType)) {
+        BasicDBList spaces = (BasicDBList) doc.get("spaces");
+        if(spaces != null) {
+          for (Object room : spaces) {
+            roomsIds.add((String) room);
+          }
         }
       }
-      if(teams != null) {
-        for (Object room : teams) {
-          roomsIds.add((String) room);
+      if(StringUtils.isBlank(roomType) ||  TYPE_ROOM_TEAM.equals(roomType)) {
+        BasicDBList teams = (BasicDBList) doc.get("teams");
+        if (teams != null) {
+          for (Object room : teams) {
+            roomsIds.add((String) room);
+          }
         }
       }
       // Add spaces and teams rooms
       orList.add(new BasicDBObject("_id", new BasicDBObject("$in", roomsIds)));
-      // Add user to user rooms
-      orList.add(new BasicDBObject("users", user));
+      if(StringUtils.isBlank(roomType) || TYPE_ROOM_USER.equals(roomType)) {
+        // Add user to user rooms
+        orList.add(new BasicDBObject("users", user));
+      }
 
       DBObject roomsQuery = new BasicDBObject("$and", andList);
       List<BasicDBObject> enabledRoomOrList = new ArrayList<>();
@@ -908,10 +931,12 @@ public class ChatMongoDataStorage implements ChatDataStorage {
 
     List<RoomBean> finalRooms = new ArrayList<RoomBean>();
     if (StringUtils.isNotBlank(filter)) {
+      roomsCount = 0;
       for (RoomBean roomBean : rooms) {
         String targetUser = roomBean.getFullName();
         if (filter(targetUser, filter))
           finalRooms.add(roomBean);
+          roomsCount ++;
       }
     } else {
       finalRooms = rooms;


### PR DESCRIPTION
Inside Chat application, the lis of contacts loads all users and then filter them. This causes a heavy load on databases for users having many chat rooms.
The fix enforces paginating contacts and loads them with offset and limit of 20 contact by once.
It includes also a fix to make user statuses consistent betwen chat drawer, contacts list and member list of a room.