### PR TITLE
TASK-36177:implemented silent option in room discussion (Back implementation)

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/services/NotificationServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/NotificationServiceImpl.java
@@ -28,6 +28,10 @@ import org.exoplatform.chat.model.RoomBean;
 import org.exoplatform.chat.services.ChatService;
 import org.exoplatform.chat.services.RealTimeMessageService;
 import org.exoplatform.chat.services.UserService;
+import org.json.JSONException;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -45,7 +49,8 @@ public class NotificationServiceImpl implements org.exoplatform.chat.services.No
 
   @Inject
   private NotificationDataStorage storage;
-
+  @Inject
+  private UserService userService;
   public void addNotification(String receiver, String sender, String type, String category, String categoryId,
                               String content, String link) {
     storage.addNotification(receiver, sender, type, category, categoryId, content, link, null);
@@ -98,15 +103,31 @@ public class NotificationServiceImpl implements org.exoplatform.chat.services.No
 
   private void sendNotification(String receiver) {
     Map<String, Object> data = new HashMap<>();
-    data.put("totalUnreadMsg", getUnreadNotificationsTotal(receiver));
+    try {
+      String bean = userService.getUserDesktopNotificationSettings(receiver).getEnabledRoomTriggers();
+      JSONParser parser = new JSONParser();
+      JSONObject json = (JSONObject) parser.parse(bean);
+      List<NotificationBean> notifications = getUnreadNotifications(receiver,userService);
+      List<NotificationBean> result = new ArrayList<>();
+      for (NotificationBean notificationBean : notifications) {
+           JSONObject settingJson =  (JSONObject)json.get(notificationBean.getCategoryId());
+           if(((settingJson.get("notifCond") != null) && settingJson.get("notifCond") == "normal") || (notificationBean.getRoomType() == "u")){
+             result.add(notificationBean);
+           }
+      }
+      data.put("totalUnreadMsg", result.size());
+      // Deliver the saved message to sender's subscribed channel itself.
+      RealTimeMessageBean messageBean = new RealTimeMessageBean(
+              RealTimeMessageBean.EventType.NOTIFICATION_COUNT_UPDATED,
+              null,
+              receiver,
+              null,
+              data);
+      realTimeMessageService.sendMessage(messageBean, receiver);
 
-    // Deliver the saved message to sender's subscribed channel itself.
-    RealTimeMessageBean messageBean = new RealTimeMessageBean(
-        RealTimeMessageBean.EventType.NOTIFICATION_COUNT_UPDATED,
-        null,
-        receiver,
-        null,
-        data);
-    realTimeMessageService.sendMessage(messageBean, receiver);
+    } catch (JSONException | ParseException e) {
+      e.printStackTrace();
+    }
+
   }
 }

--- a/server-embedded/src/test/java/org/exoplatform/chat/ChatTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/ChatTestCase.java
@@ -9,19 +9,27 @@ import org.exoplatform.chat.model.SpaceBean;
 import org.exoplatform.chat.services.*;
 import org.exoplatform.chat.services.mongodb.ChatMongoDataStorage;
 import org.exoplatform.chat.services.mongodb.UserMongoDataStorage;
+import org.json.JSONException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.simple.JSONObject;
+import org.mockito.Mock;
+
+import javax.annotation.meta.When;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 public class ChatTestCase extends AbstractChatTestCase
 {
+  @Mock
+  UserService userService;
   @Before
   public void setUp()
   {
@@ -41,7 +49,7 @@ public class ChatTestCase extends AbstractChatTestCase
 
     ConnectionManager.getInstance().getDB().getCollection(UserMongoDataStorage.M_USERS_COLLECTION).drop();
 
-    UserService userService = ServiceBootstrap.getUserService();
+     this.userService = ServiceBootstrap.getUserService();
     userService.addUserFullName("benjamin", "Benjamin Paillereau");
     userService.addUserEmail("benjamin", "bpaillereau@exoplatform.com");
     userService.addUserFullName("john", "John Smith");
@@ -55,6 +63,7 @@ public class ChatTestCase extends AbstractChatTestCase
   @Test
   public void testGetRoom() throws Exception
   {
+
     ChatService chatService = ServiceBootstrap.getChatService();
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
@@ -267,6 +276,9 @@ public class ChatTestCase extends AbstractChatTestCase
   @Test
   public void testGetExistingRooms() throws Exception
   {
+    String settings = "{ \"7e627d568016638322c641744e68bad9d97be780\" : { \"notifCond\" : \"silence\" , \"time\" : 1619190209010}}";
+    when(userService.getUserDesktopNotificationSettings("jhon").getEnabledRoomTriggers()).thenReturn(settings);
+
     ChatService chatService = ServiceBootstrap.getChatService();
     TokenService tokenService = ServiceBootstrap.getTokenService();
     NotificationService notificationService = ServiceBootstrap.getNotificationService();


### PR DESCRIPTION
before this fix , even when you activate silent option in a room you continue to receive notifications on desktop and in the chat badge , so i implemented this option on the chat badge by adding a filter method to filter notifications by room mode and also removed some unnecessary code that was computing the number of unread messages which was unuseful and duplicated.