### PR TITLE
TASK-46251: add missing prettyName field for space room

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -634,6 +634,7 @@ public class UserMongoDataStorage implements UserDataStorage {
       }
       if (ChatService.TYPE_ROOM_SPACE.equals(type))
       {
+        roomBean.setPrettyName(doc.get("prettyName").toString());
         roomBean.setUser(ChatService.SPACE_PREFIX+roomId);
         roomBean.setFullName(doc.get("displayName").toString());
         if (doc.containsField("meetingStarted")) {


### PR DESCRIPTION
The space pretty name was missing in the space room object. I added it in order to well initialize the chat drawer when opening it from the space popover. 