### PR TITLE
Task-42993: Chat - can’t add users added by AD synchro to a private chatroom

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserEventListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UpdateUserEventListener.java
@@ -10,10 +10,7 @@ public class UpdateUserEventListener extends UserEventListener {
 
   private static final Log LOG = ExoLogger.getLogger(UpdateUserEventListener.class.getName());
 
-  public void postSave(User user, boolean isNew) throws Exception {
-    if (ConversationState.getCurrent() == null) {
-      return;
-    }
+  public void postSave(User user, boolean isNew) {
     try {
       ServerBootstrap.addUserFullNameAndEmail(user.getUserName(), user.getDisplayName(), user.getEmail());
     } catch (Exception e) {


### PR DESCRIPTION
problem : Can’t add users added by AD synchronization to a private chatroom unless when they connect to the platform for a first .
When AD synchronizing users, ConversationState.getCurrent () is null, so the chat db will not be updated.