### PR TITLE
Security Fix : Upgrade quartz from 2.2.2 to 2.3.2.

### DIFF
--- a/common/src/main/java/org/exoplatform/chat/utils/PropertyManager.java
+++ b/common/src/main/java/org/exoplatform/chat/utils/PropertyManager.java
@@ -146,7 +146,7 @@ public class PropertyManager {
       overridePropertyIfNotSet(PROPERTY_CHAT_PORTAL_PAGE, "/portal/intranet/chat");
       overridePropertyIfNotSet(PROPERTY_INTERVAL_SESSION, "60000");
       overridePropertyIfNotSet(PROPERTY_PASSPHRASE, "chat");
-      overridePropertyIfNotSet(PROPERTY_CRON_NOTIF_CLEANUP, "0 0/60 * * * ?");
+      overridePropertyIfNotSet(PROPERTY_CRON_NOTIF_CLEANUP, "0 0 * * * ?");
       overridePropertyIfNotSet(PROPERTY_PUBLIC_ADMIN_GROUP, "/platform/administrators");
       overridePropertyIfNotSet(PROPERTY_TEAM_ADMIN_GROUP, "/platform/users");
       overridePropertyIfNotSet(PROPERTY_TOKEN_VALIDITY, "60000");

--- a/common/src/test/java/org/exoplatform/chat/utils/PropertyManagerTestCase.java
+++ b/common/src/test/java/org/exoplatform/chat/utils/PropertyManagerTestCase.java
@@ -55,7 +55,7 @@ public class PropertyManagerTestCase {
     Assert.assertEquals("/portal/intranet/chat", PropertyManager.getProperty(PropertyManager.PROPERTY_CHAT_PORTAL_PAGE));
     Assert.assertEquals("60000", PropertyManager.getProperty(PropertyManager.PROPERTY_INTERVAL_SESSION));
     Assert.assertEquals("chat", PropertyManager.getProperty(PropertyManager.PROPERTY_PASSPHRASE));
-    Assert.assertEquals("0 0/60 * * * ?", PropertyManager.getProperty(PropertyManager.PROPERTY_CRON_NOTIF_CLEANUP));
+    Assert.assertEquals("0 0 * * * ?", PropertyManager.getProperty(PropertyManager.PROPERTY_CRON_NOTIF_CLEANUP));
     Assert.assertEquals("/platform/administrators", PropertyManager.getProperty(PropertyManager.PROPERTY_PUBLIC_ADMIN_GROUP));
     Assert.assertEquals("/platform/users", PropertyManager.getProperty(PropertyManager.PROPERTY_TEAM_ADMIN_GROUP));
     Assert.assertEquals("60000", PropertyManager.getProperty(PropertyManager.PROPERTY_TOKEN_VALIDITY));

--- a/data/chat-sample.properties
+++ b/data/chat-sample.properties
@@ -76,7 +76,7 @@
 # Cron job value to clean read notifications periodically.
 # Use the Cron Expression syntax (http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06).
 # Defaut value is every hour.
-#chatCronNotifCleanup=0 0/60 * * * ?
+#chatCronNotifCleanup=0 0 * * * ?
 
 # eXo group who can create Teams. Default value is /platform/users.
 #teamAdminGroup=/platform/users

--- a/data/chat-single.properties
+++ b/data/chat-single.properties
@@ -12,7 +12,7 @@ chatIntervalSession=60000
 
 chatPassPhrase=chat
 
-chatCronNotifCleanup=0 0/60 * * * ?
+chatCronNotifCleanup=0 0 * * * ?
 
 publicAdminGroup=/platform/administrators
 

--- a/data/chat.properties
+++ b/data/chat.properties
@@ -73,7 +73,7 @@
 # Cron job value to clean read notifications periodically.
 # Use the Cron Expression syntax (http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06).
 # Defaut value is every hour.
-#chatCronNotifCleanup=0 0/60 * * * ?
+#chatCronNotifCleanup=0 0 * * * ?
 
 # eXo group who can create Teams. Default value is /platform/users.
 #teamAdminGroup=/platform/users


### PR DESCRIPTION
With this upgrade the syntax 0/60 is no more valid. The expression '0 0/60 * * * ?' is equivalent to '0 0 * * * ?' which is valid