### PR TITLE
Task-48058: Fix technical names in Chat notification bloc

### DIFF
--- a/extension/src/main/webapp/WEB-INF/conf/chat/notification-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/notification-configuration.xml
@@ -48,7 +48,7 @@
                             <string>ChatMentionNotificationPlugin</string>
                         </field>
                         <field name="resourceBundleKey">
-                            <string>exoplatform.chat.ChatMentionNotificationPlugin</string>
+                            <string>UINotification.label.ChatMentionNotificationPlugin</string>
                         </field>
                         <field name="order">
                             <string>11</string>


### PR DESCRIPTION
**Problem:** the Chat `resourceBundleKey` String content is wrong .
**Solution:** `resourceBundleKey` String content  change to UINotification.label.ChatMentionNotificationPlugin.