### PR TITLE
TASK-47018: fix sending multiple messages after connection is reestablished

### DIFF
--- a/application/src/main/webapp/css/components/chatMessage.less
+++ b/application/src/main/webapp/css/components/chatMessage.less
@@ -170,6 +170,9 @@
   .uiIconNotification {
     top: -2px;
   }
+  .delete-message-icon {
+    color: #c72222 !important;
+  }
 }
 .custom-message-item {
   margin-top: 5px;

--- a/application/src/main/webapp/vue-app/chatConstants.js
+++ b/application/src/main/webapp/vue-app/chatConstants.js
@@ -103,6 +103,8 @@ export const chatConstants = {
   EVENT_ROOM_SELECTION_CHANGED: 'exo-chat-selected-contact-changed',
   EVENT_USER_SETTINGS_LOADED: 'exo-chat-settings-loaded',
   EVENT_USER_STATUS_CHANGED: 'exo-chat-user-status-changed',
+  RESEND_FAILED_MESSAGE: 'exo-chat-resend-failed-message',
+  DELETE_FAILED_MESSAGE: 'exo-chat-delete-failed-message',
   DEFAULT_OFFSET: 0,
   DEFAULT_USER_LIMIT: 20
 };

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -230,13 +230,13 @@ export default {
         if (indexOfRoom < 0) {
           this.contactList.unshift(selectedContact);
         }
-        this.selectedContact = selectedContact;
         this.contactOpened = false;
         chatServices.getRoomParticipantsCount(eXo.chat.userSettings, selectedContact).then( data => {
           this.selectedContact.participantsCount = data.usersCount;
           this.selectedContact.activeParticipantsCount = data.activeUsersCount;
         });
         chatServices.getRoomParticipants(eXo.chat.userSettings, selectedContact).then( data => {
+          this.selectedContact = selectedContact;
           this.selectedContact.participants = data.users;
           document.dispatchEvent(new CustomEvent(chatConstants.EVENT_ROOM_SELECTION_CHANGED, {'detail': this.selectedContact}));
         });

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
@@ -152,8 +152,14 @@
         <i v-else-if="message.options && messageOptionsType === chatConstants.EVENT_MESSAGE" class="uiIconChatCreateEvent"></i>
         <i v-else-if="message.options && (messageOptionsType === chatConstants.MEETING_START_MESSAGE || messageOptionsType === chatConstants.MEETING_STOP_MESSAGE || messageOptionsType === chatConstants.NOTES_MESSAGE)" class="uiIconChatMeeting"></i>
         <i v-else-if="isSpecificMessageType && specificMessageClass" :class="specificMessageClass"></i>
-
-        <i v-exo-tooltip.top="$t('exoplatform.chat.msg.notDelivered')" class="uiIconNotification"></i>
+        <i
+          :class="!message.notSent && 'hidden'"
+          class="uiIcon16x16 primary--text clickable mdi mdi-refresh"
+          @click="sendFailedMessage()"></i>
+        <i
+          :class="!message.notSent && 'hidden'"
+          class="uiIcon16x16 delete-message-icon clickable mdi mdi-delete"
+          @click="deleteFailedMessage()"></i>
       </div>
     </div>
     <div class="chat-message-action">
@@ -194,8 +200,13 @@
           </li>
         </ul>
       </div>
+      <i
+        v-else
+        v-exo-tooltip.top="$t('exoplatform.chat.msg.notDelivered')"
+        class="uiIconNotification"></i>
       <div v-if="!hideTime" class="message-time">{{ dateString }}</div>
     </div>
+
     <exo-chat-modal
       v-show="showConfirmModal"
       :title="$t(confirmTitle)"
@@ -594,6 +605,20 @@ export default {
     },
     getProfileLink(user) {
       return chatServices.getUserProfileLink(user);
+    },
+    sendFailedMessage() {
+      document.dispatchEvent(
+        new CustomEvent(chatConstants.RESEND_FAILED_MESSAGE, {
+          detail: {user: eXo.chat.userSettings.username, message: this.message}
+        })
+      );
+    },
+    deleteFailedMessage() {
+      document.dispatchEvent(
+        new CustomEvent(chatConstants.DELETE_FAILED_MESSAGE, {
+          detail: {user: eXo.chat.userSettings.username, clientId: this.message.clientId}
+        })
+      );
     }
   }
 };

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -123,7 +123,10 @@
       </exo-drawer>
     </v-app>
     <div class="hide">
-      <audio id="chat-audio-notif" controls hidden="hidden">
+      <audio
+        id="chat-audio-notif"
+        controls
+        hidden="hidden">
         <source src="/chat/audio/notif.wav">
         <source src="/chat/audio/notif.mp3">
         <source src="/chat/audio/notif.ogg">


### PR DESCRIPTION
The problem was that the websocket was not closed when the internet connection is off. And there were several attempts to send the message when the internet is reestablished.

We agreed to disable the auto-try to send failed messages and replace it with a better UX to let the user decide whether to cancel the send or retry.