### PR TITLE
Task-48152: Fix the display of external indication on user popover from people list in room chat

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
@@ -77,7 +77,7 @@ export default {
           Connect: vnode.context.$t('exoplatform.chat.user.popup.connect'),
           Confirm: vnode.context.$t('exoplatform.chat.user.popup.confirm'),
           CancelRequest: vnode.context.$t('exoplatform.chat.user.popup.cancel'),
-          External: vnode.context.$t('exoplatform.chat.user.popup.external'),
+          External: vnode.context.$t('exoplatform.chat.external'),
           RemoveConnection: vnode.context.$t('exoplatform.chat.user.popup.remove.connection')
         },
         content: false,


### PR DESCRIPTION
**Problem:** external indication in user popover not shown because we use the wrong property in `Resource_en.properties`.
**Solution:** use the right properties `exoplatform.chat.external`.