### PR TITLE
Task-48008: Fix mention external user in the space room

### DIFF
--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -418,6 +418,24 @@ export function getRoomParticipantsToSuggest(usersList) {
   });
 }
 
+export function getModalParticipantsToSuggest(usersList) {
+  return fetch(`${chatConstants.PORTAL}/${chatConstants.PORTAL_REST}${chatConstants.CHAT_API}getModalParticipantsToSuggest`, {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    credentials: 'include',
+    method: 'POST',
+    body: JSON.stringify(usersList),
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.json();
+    }
+    else {
+      throw new Error ('Error when loading user list');
+    }
+  });
+}
+
 
 export function getUserProfileLink(user) {
   return `${chatConstants.PORTAL}/${chatConstants.PORTAL_NAME}/${chatConstants.PROFILE_PAGE_NAME}/${user}`;

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatRoomFormModal.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatRoomFormModal.vue
@@ -163,7 +163,7 @@ export default {
       }
       chatServices.getChatUsers(eXo.chat.userSettings, query).then(data => {
         if (data && data.users) {
-          chatServices.getRoomParticipantsToSuggest(data.users).then(users => {
+          chatServices.getModalParticipantsToSuggest(data.users).then(users => {
             users.forEach(user => {
               if (user.isEnabled === 'null') {
                 chatServices.getUserState(user.name).then(userState => {


### PR DESCRIPTION
**Problem:**  `getRoomParticipantsToSuggest` rest API method used to suggest a participant in chat composer message and the creation room modals. For case of the creation room modals we add only connections and other non external users as room participants, in the other case we can suggest external users and space members.
**Solution:**  For each case, we must add a specific rest API method to get the right result