### PR TITLE
TASK-47018: Add check on internet connection when sending a message in chat

### DIFF
--- a/application/src/main/webapp/vue-app/chatWebSocket.js
+++ b/application/src/main/webapp/vue-app/chatWebSocket.js
@@ -172,7 +172,7 @@ export function sendMessage(messageObj, callback) {
     'fullname': cometDSettings.fullname
   };
 
-  if (!isConnected()) {
+  if (!isConnected() || !navigator.onLine) {
     document.dispatchEvent(new CustomEvent(chatConstants.EVENT_MESSAGE_NOT_SENT, {'detail': data}));
     document.dispatchEvent(new CustomEvent(chatConstants.EVENT_DISCONNECTED));
     return;


### PR DESCRIPTION
Websocket is based on TCP and TCP uses FIN packet to close the connection. So when the internet is off, Websocket is unaware as there is no FIN packet was sent and it keeps sending the message and trying until a connection is established.

This fix makes a check from the client's side on the internet connection to not let the websocket try to send the message.