### PR TITLE
TASK-40995:External user flag is still displayed next to the user fullname

### DIFF
--- a/extension/src/main/webapp/WEB-INF/conf/chat/listener-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/listener-configuration.xml
@@ -21,4 +21,13 @@
             <type>org.exoplatform.addons.chat.listener.UpdateUserEventListener</type>
         </component-plugin>
     </external-component-plugins>
+    <external-component-plugins>
+        <target-component>org.exoplatform.services.organization.OrganizationService</target-component>
+        <component-plugin>
+            <name>external.user.listener</name>
+            <set-method>addListenerPlugin</set-method>
+            <type>org.exoplatform.addons.chat.listener.ExternalUserListener</type>
+            <description>Update external user property</description>
+        </component-plugin>
+    </external-component-plugins>
 </configuration>

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/ExternalUserListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/ExternalUserListener.java
@@ -1,0 +1,36 @@
+package org.exoplatform.addons.chat.listener;
+
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Membership;
+import org.exoplatform.services.organization.MembershipEventListener;
+
+public class ExternalUserListener extends MembershipEventListener {
+
+  private static final Log LOG = ExoLogger.getLogger(ExternalUserListener.class);
+  private static final String PLATFORM_EXTERNALS_GROUP  = "/platform/externals";
+
+
+  @Override
+  public void postSave(Membership m, boolean isNew) {
+    if (m.getGroupId().equals(PLATFORM_EXTERNALS_GROUP)) {
+      try {
+        ServerBootstrap.setExternalUser(m.getUserName(),"true");
+      } catch (Exception e) {
+        LOG.error("Error while saving the external property for user  {}", m.getUserName(), e);
+      }
+    }
+  }
+
+  @Override
+  public void postDelete(Membership m) {
+    if (m.getGroupId().equals(PLATFORM_EXTERNALS_GROUP)) {
+      try {
+        ServerBootstrap.setExternalUser(m.getUserName(),"false");
+      } catch (Exception e) {
+        LOG.error("Error while saving the external property for user  {}", m.getUserName(), e);
+      }
+    }
+  }
+
+}

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UserLoginListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UserLoginListener.java
@@ -1,14 +1,8 @@
 package org.exoplatform.addons.chat.listener;
 
 import org.apache.commons.lang3.StringUtils;
-
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.*;
 import org.exoplatform.services.security.*;
-import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-import org.exoplatform.social.core.manager.IdentityManager;
-
 /**
  * This listener will be used to update current user chat rooms list on login.
  */
@@ -23,12 +17,6 @@ public class UserLoginListener extends Listener<ConversationRegistry, Conversati
 
     if (StringUtils.isBlank(userId) || StringUtils.equalsIgnoreCase(userId, IdentityConstants.ANONIM)) {
       return;
-    }
-    IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
-    Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userId);
-    Boolean isExternal = identity.getProfile() !=  null && identity.getProfile().getProperty("external") != null  && identity.getProfile().getProperty("external").equals("true");
-    if(isExternal) {
-      ServerBootstrap.setExternalUser(userId, isExternal.toString());
     }
     ServerBootstrap.saveSpaces(userId);
     if (Boolean.valueOf(ServerBootstrap.shouldUpdate(userId))) {


### PR DESCRIPTION
when adding a user to  "External group " an external flag must be displayed next to his name in chat room and chat drawer 
the External Flag isn't always displayed because in the actual behavior    setting user property is set when the user log in  and not updated when removed from 
Added a listener from MembershipEventListener to update the user enabled property one added or removed from "External group "