### PR TITLE
Task-48189: Fix display of chat notification's title

### DIFF
--- a/services/src/main/resources/locale/portlet/chat/Resource.properties
+++ b/services/src/main/resources/locale/portlet/chat/Resource.properties
@@ -259,3 +259,4 @@ Notification.ChatMentionNotificationPlugin.label.SayHello=Hello
 Notification.ChatMentionNotificationPlugin.label.footer=If you do not want to receive such notifications, <a target="_blank" class="notification_settings_url" href="{0}">click here</a> to change your notification settings.
 # For UI
 UINotification.title.ChatMentionNotificationPlugin=Someone mentions me in chat
+UINotification.label.ChatMentionNotificationPlugin=Mention in chat


### PR DESCRIPTION
Issue: The title of chat notification is displayed with the technical name.
This change adds the missing property for label chat notifications title.