### PR TITLE
Task-48652:Remove typed letter after selected the user on chat room users suggester (#353)

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatRoomFormModal.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatRoomFormModal.vue
@@ -19,6 +19,7 @@
           ref="invitedPeopleAutoComplete"
           v-model="participants"
           :search-options="{}"
+          :key="participants"
           name="invitePeople"
           multiple
           include-users />


### PR DESCRIPTION
Issue: The typed letter is still displayed after selecting users from the suggested list.
Solution: Add a key to exo-identity-suggester. in fact, the key as participants is the model of the component, each time the list of participants changes when you select a new user, this changes the value of the key, which forces the component to re-render and this will list just the participants and will remove automatically the extra typed text.
(cherry picked from commit 098a0fa9cb1ac14de33f2914ef14dc5aed2d26e3)