### PR TITLE
Task-44202 : Chat messages notification but nothing visible when opening the chat drawer

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -317,7 +317,7 @@ export default {
       // force update room unread msg
       this.contactList.forEach(contact => {
         const indexOfRoom = rooms.findIndex(room => room.room === contact.room || room.user === contact.user);
-        if (rooms[indexOfRoom].unreadTotal !== contact.unreadTotal) {
+        if (indexOfRoom >= 0 && rooms[indexOfRoom].unreadTotal !== contact.unreadTotal) {
           contact.unreadTotal = rooms[indexOfRoom].unreadTotal;
         }
       });


### PR DESCRIPTION
Prior this fix, when open a chat notification in a page that is inactive for a while, the drawer does not update with the correct number of unread messages.
Fix: Make sure to update the number of unread messages in the chat rooms each time the drawer is opened.