### PR TITLE
Task-44202 : Chat messages notification but nothing visible when opening the chat drawer

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -285,6 +285,7 @@ export default {
       const totalUnreadMsg = e.detail ? e.detail.data.totalUnreadMsg : e.totalUnreadMsg;
       if (totalUnreadMsg >= 0) {
         this.totalUnreadMsg = totalUnreadMsg;
+        this.refreshContacts(true);
       }
     },
     userStatusChanged(e) {


### PR DESCRIPTION
Prior this fix, when open a chat notification in a page that is inactive for a while, the drawer does not update with the correct number of unread messages.
Fix: Make sure to update the number of unread messages in the chat rooms each time the drawer is opened.