### PR TITLE
Task-49693: No notification when a user sends a chat message and that he does not belong to first discussions

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -737,7 +737,6 @@ public class ChatServer
       if ("true".equals(withDetail)) {
         roomBean = userService.getRoom(user, room);
       }
-      notificationService.setNotificationsAsRead(user, "chat", "room", room);
     }
     catch (Exception e)
     {


### PR DESCRIPTION
Prior this change, when user sends a chat message and that he does not belong to first discussions, there no notification received.
Fix : update getRoom function to not mark message as read.