### PR TITLE
MAINT-50662: Fix chat infinite loop in setting user status (#381)

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -282,7 +282,7 @@ export default {
     connectionEstablished() {
       eXo.chat.isOnline = true;
       this.connected = true;
-      if (this.userSettings.originalStatus !== this.userSettings.status) {
+      if (this.userSettings.originalStatus && this.userSettings.originalStatus !== this.userSettings.status) {
         this.setStatus(this.userSettings.originalStatus);
       } else if (this.userSettings && this.userSettings.originalStatus) {
         this.userSettings.status = this.userSettings.originalStatus;

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -285,7 +285,7 @@ export default {
     },
     connectionEstablished() {
       eXo.chat.isOnline = true;
-      if (this.userSettings.originalStatus !== this.userSettings.status) {
+      if (this.userSettings.originalStatus && this.userSettings.originalStatus !== this.userSettings.status) {
         this.setStatus(this.userSettings.originalStatus);
       } else if (this.userSettings && this.userSettings.originalStatus) {
         this.userSettings.status = this.userSettings.originalStatus;


### PR DESCRIPTION
**ISSUE**: when the user connected and dispatched event from the websocket is sent, there was a try to set un undefined value of status and infinte attempts without success
**FIX**: Add a check on the value to be set as a user status to avoid such failed infinite retries