### PR TITLE
MAINT-50584: Fix users and rooms avatar urls retrieving (#380)

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -6,6 +6,7 @@
           :user-name="userSettings.username"
           :name="userSettings.fullName"
           :status="userSettings.status"
+          :avatar-url="userSettings.avatarUrl"
           :is-current-user="true"
           type="u"
           @status-changed="setStatus($event)">

--- a/application/src/main/webapp/vue-app/components/ExoChatContact.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContact.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="chat-contact">
     <div
-      :style="`backgroundImage: url(${avatarUrl})`"
+      :style="`backgroundImage: url(${avatarUrl? avatarUrl : defaultRoomAvatar})`"
       :class="statusStyle"
       class="chat-contact-avatar">
       <a
@@ -58,7 +58,7 @@
 </template>
 
 <script>
-import { getUserInfo, getSpaceByPrettyName, getUserProfileLink, getSpaceProfileLink, escapeHtml } from '../chatServices';
+import {getUserProfileLink, getSpaceProfileLink, escapeHtml } from '../chatServices';
 import {chatConstants} from '../chatConstants';
 
 export default {
@@ -132,6 +132,10 @@ export default {
     chatDrawerContact: {
       type: Boolean,
       default: false
+    },
+    avatarUrl: {
+      type: String,
+      default: null
     }
   },
   data: function() {
@@ -151,7 +155,7 @@ export default {
         donotdisturb: this.$t('exoplatform.chat.donotdisturb'),
         invisible: this.$t('exoplatform.chat.invisible'),
       },
-      avatarUrl: '',
+      defaultRoomAvatar: chatConstants.DEFAULT_ROOM_AVATAR,
     };
   },
   computed: {
@@ -199,7 +203,6 @@ export default {
     document.addEventListener(chatConstants.EVENT_DISCONNECTED, this.setOffline);
     document.addEventListener(chatConstants.EVENT_CONNECTED, this.setOnline);
     document.addEventListener(chatConstants.EVENT_RECONNECTED, this.setOnline);
-    this.retrieveAvatarUrl();
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_DISCONNECTED, this.setOffline);
@@ -216,19 +219,6 @@ export default {
     setOffline() {
       this.isOnline = false;
     },
-    retrieveAvatarUrl() {
-      if (this.type === 'u') {
-        getUserInfo(this.userName).then((user) => {
-          this.avatarUrl = user.avatar;
-        });
-      } else if (this.type === 's') {
-        getSpaceByPrettyName(this.prettyName).then((data) => {
-          this.avatarUrl = data.avatarUrl;
-        });
-      } else {
-        this.avatarUrl = chatConstants.DEFAULT_ROOM_AVATAR;
-      }
-    }
   }
 };
 </script>

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -87,6 +87,7 @@
             :group-id="contact.groupId"
             :name="contact.fullName"
             :status="contact.status"
+            :avatar-url="contact.avatarUrl"
             :last-message="getLastMessage(contact.lastMessage, contact.type)">
             <div
               v-if="mq === 'mobile'"

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -185,10 +185,8 @@ export default {
         dropdownParent: 'body',
         hideSelected: true,
         renderMenuItem: function (item) {
-          component.retrieveAvatarUrl(item.name);
-          const avatar = this.userAvatar;
           const defaultAvatar = '/chat/img/room-default.jpg';
-          return `<img src="${avatar}" onerror="this.src='${defaultAvatar}'" width="20px" height="20px">
+          return `<img src="${item.avatarUrl}" onerror="this.src='${defaultAvatar}'" width="20px" height="20px">
                       ${chatServices.escapeHtml(item.fullname)}<span style="float: right" class="chat-status-task chat-status-'+item.status+'"></span>`;
         },
         /* eslint-disable no-template-curly-in-string */
@@ -347,11 +345,6 @@ export default {
       chatServices.sendMentionNotification(this.contact.room, this.contact.fullName, this.mentionedUsers);
       this.mentionedUsers = [];
       return message;
-    },
-    retrieveAvatarUrl(username) {
-      chatServices.getUserInfo(username).then((data) => {
-        this.userAvatar = data.avatar;
-      });
     },
   }
 };

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
@@ -10,6 +10,7 @@
       :pretty-name="contact.prettyName"
       :group-id="contact.groupId"
       :name="contact.fullName"
+      :avatar-url="contact.avatarUrl"
       :status="contact.status"
       :nb-members="nbMembers">
       <div

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomParticipants.vue
@@ -50,6 +50,7 @@
             :user-name="participant.name"
             :name="participant.fullname"
             :status="participant.status"
+            :avatar-url="participant.avatarUrl"
             type="u" />
         </div>
         <div v-show="!isCollapsed || mq === 'mobile'" class="room-participants-title">

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -26,6 +26,7 @@
                 :chat-drawer-contact="showChatDrawer"
                 :user-name="userSettings.username"
                 :status="userSettings.status"
+                :avatar-url="userSettings.avatarUrl"
                 :is-current-user="true"
                 type="u"
                 @status-changed="setStatus($event)" />
@@ -36,9 +37,9 @@
               @click="backChat()">
               mdi-keyboard-backspace
             </v-icon>
-            <span v-if="selectedContact && avatarUrl">
+            <span v-if="selectedContact">
               <img
-                :src="avatarUrl"
+                :src="selectedContact.avatarUrl ? selectedContact.avatarUrl : defaultRoomAvatarUrl"
                 class="chatAvatar"
                 alt="avatar of discussion">
               <span :class="statusStyle" class="user-status">
@@ -141,7 +142,6 @@ import {chatConstants} from '../../chatConstants';
 import * as chatWebSocket from '../../chatWebSocket';
 import * as desktopNotification from '../../desktopNotification';
 import {miniChatTitleActionComponents} from '../../extension';
-import {getSpaceByPrettyName, getUserInfo} from '../../chatServices';
 
 export default {
   name: 'ExoChatDrawer',
@@ -163,7 +163,7 @@ export default {
       external: this.$t('exoplatform.chat.external'),
       chatLink: `/portal/${eXo.env.portal.portalName}/chat`,
       titleActionComponents: miniChatTitleActionComponents,
-      avatarUrl: '',
+      defaultRoomAvatarUrl: chatConstants.DEFAULT_ROOM_AVATAR
     };
   },
   computed: {
@@ -361,7 +361,6 @@ export default {
       });
     },
     setSelectedContact(selectedContact) {
-      this.avatarUrl = null;
       if (!selectedContact && selectedContact.length() === 0) {
         selectedContact = {};
       }
@@ -382,7 +381,6 @@ export default {
         this.selectedContact.participants = data.users;
         document.dispatchEvent(new CustomEvent(chatConstants.EVENT_ROOM_SELECTION_CHANGED, {'detail': this.selectedContact}));
       });
-      this.retrieveAvatarUrl();
       this.showSearch = false;
     },
     refreshContacts(keepSelectedContact) {
@@ -463,21 +461,6 @@ export default {
         }
       }
     },
-    retrieveAvatarUrl() {
-      if (this.selectedContact) {
-        if (this.selectedContact.type === 'u') {
-          getUserInfo(this.selectedContact.user).then((user) => {
-            this.avatarUrl = user.avatar;
-          });
-        } else if (this.selectedContact.type === 's') {
-          getSpaceByPrettyName(this.selectedContact.prettyName).then((space) => {
-            this.avatarUrl = space.avatarUrl;
-          });
-        } else {
-          this.avatarUrl = chatConstants.DEFAULT_ROOM_AVATAR;
-        }
-      }
-    }
   }
 };
 </script>

--- a/common/src/main/java/org/exoplatform/chat/model/RoomBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/RoomBean.java
@@ -45,6 +45,7 @@ public class RoomBean implements Comparable<RoomBean>
   long timestamp = -1;
   org.json.JSONObject lastMessage;
   String groupId;
+  private String avatarUrl = "";
 
   public String getPrettyName() {
     return prettyName;
@@ -200,6 +201,14 @@ public class RoomBean implements Comparable<RoomBean>
     this.enabledRoom = enabledRoom;
   }
 
+  public String getAvatarUrl() {
+    return avatarUrl;
+  }
+
+  public void setAvatarUrl(String avatarUrl) {
+    this.avatarUrl = avatarUrl;
+  }
+
   @SuppressWarnings("unchecked")
   public JSONObject toJSONObject() {
     JSONObject obj = new JSONObject();
@@ -222,6 +231,7 @@ public class RoomBean implements Comparable<RoomBean>
     if(this.getGroupId() != null && !this.getGroupId().isEmpty()) {
       obj.put("groupId", this.getGroupId());
     }
+    obj.put("avatarUrl", this.getAvatarUrl());
     if (this.getAdmins() != null) {
       try {
         obj.put("admins", new JSONArray(this.getAdmins()));

--- a/common/src/main/java/org/exoplatform/chat/model/UserBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/UserBean.java
@@ -27,6 +27,7 @@ public class UserBean
   private String name, fullname="", isExternal="", email="", status;
   private List<String> favorites;
   private Boolean enabled, deleted;
+  private String avatarUrl;
 
   public String getName()
   {
@@ -113,6 +114,14 @@ public class UserBean
     return this.enabled == null || this.enabled ? true : false;
   }
 
+  public String getAvatarUrl() {
+    return avatarUrl;
+  }
+
+  public void setAvatarUrl(String avatarUrl) {
+    this.avatarUrl = avatarUrl;
+  }
+
   public String toJSON()
   {
     StringBuffer sb = new StringBuffer();
@@ -125,7 +134,8 @@ public class UserBean
     sb.append("\"fullname\": \"" + this.getFullname() + "\",");
     sb.append("\"isEnabled\": \"" + this.isEnabled() + "\",");
     sb.append("\"isDeleted\": \"" + this.isDeleted() + "\",");
-    sb.append("\"isExternal\": \"" + this.isExternal() + "\"");
+    sb.append("\"isExternal\": \"" + this.isExternal() + "\",");
+    sb.append("\"avatarUrl\": \"" + this.getAvatarUrl() + "\"");
 
     sb.append("}");
 

--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -132,10 +132,25 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.addons.chat</groupId>
       <artifactId>chat-common</artifactId>
       <scope>provided</scope>
     </dependency>
+      <dependency>
+          <groupId>org.exoplatform.addons.chat</groupId>
+          <artifactId>chat-services</artifactId>
+        <scope>provided</scope>
+      </dependency>
   </dependencies>
   <build>
     <finalName>chatServer</finalName>

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -67,6 +67,8 @@ import juzu.template.Template;
 
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.portal.localization.LocaleContextInfoUtils;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.LocalePolicy;
@@ -142,10 +144,15 @@ public class ChatServer
 
     List<String> limitUsers = Arrays.asList(onlineUsers.split(","));
 
-    RoomsBean roomsBean = chatService.getUserRooms(user, limitUsers, filter, offsetValue, limitValue,
-            notificationService, tokenService, roomType);
-
-
+    PortalContainer container = PortalContainer.getInstance();
+    RequestLifeCycle.begin(container);
+    RoomsBean roomsBean;
+    try {
+      roomsBean = chatService.getUserRooms(user, limitUsers, filter, offsetValue, limitValue,
+              notificationService, tokenService, roomType);
+    } finally {
+      RequestLifeCycle.end();
+    }
     return Response.ok(roomsBean.roomsToJSON()).withMimeType("application/json").withHeader
             ("Cache-Control", "no-cache").withCharset(Tools.UTF_8);
   }
@@ -1098,8 +1105,15 @@ public class ChatServer
     }
 
     List<String> onlineUserList = StringUtils.isNotBlank(onlineUsers) ? Arrays.asList(onlineUsers.split(",")) : null;
-    List<UserBean> users = userService.getUsers(room, onlineUserList, filter, limit_, showOnlyOnlineUsers);
-    if(StringUtils.isNotBlank(user)) {
+    PortalContainer container = PortalContainer.getInstance();
+    RequestLifeCycle.begin(container);
+    List<UserBean> users;
+    try {
+      users = userService.getUsers(room, onlineUserList, filter, limit_, showOnlyOnlineUsers);
+    } finally {
+      RequestLifeCycle.end();
+    }
+    if (StringUtils.isNotBlank(user)) {
       UserBean currentUser = userService.getUser(user);
       users.remove(currentUser);
     }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
@@ -22,6 +22,7 @@ package org.exoplatform.chat.services.mongodb;
 import com.mongodb.*;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
+import org.exoplatform.addons.chat.utils.ChatRoomUtils;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.model.*;
 import org.exoplatform.chat.services.*;
@@ -1016,6 +1017,10 @@ public class ChatMongoDataStorage implements ChatDataStorage {
           }
           roomBean.setUser(targetUser);
           roomBean.setType(TYPE_ROOM_USER);
+          String avatar = ChatRoomUtils.getUserAvatar(roomBean.getUser());
+          if (avatar != null) {
+            roomBean.setAvatarUrl(avatar);
+          }
         }
         break;
       }
@@ -1029,8 +1034,11 @@ public class ChatMongoDataStorage implements ChatDataStorage {
         roomBean.setGroupId(room.get("groupId").toString());
         if (room.containsField("prettyName")) {
           roomBean.setPrettyName(room.get("prettyName").toString());
+          String avatar = ChatRoomUtils.getSpaceAvatar(roomBean.getPrettyName());
+          if (avatar != null) {
+            roomBean.setAvatarUrl(avatar);
+          }
         }
-
         roomBean.setFavorite(userBean.isFavorite(roomId));
         break;
       }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -22,6 +22,7 @@ package org.exoplatform.chat.services.mongodb;
 import com.mongodb.*;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.addons.chat.utils.ChatRoomUtils;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.model.*;
 import org.exoplatform.chat.services.ChatService;
@@ -863,6 +864,10 @@ public class UserMongoDataStorage implements UserDataStorage {
           }
           if (doc.get("isExternal") != null) {
             userBean.setExternal(doc.get("isExternal").toString());
+          }
+          String avatar = ChatRoomUtils.getUserAvatar(userBean.getName());
+          if (avatar != null) {
+            userBean.setAvatarUrl(avatar);
           }
           users.add(userBean);
         }

--- a/server-embedded/src/test/java/org/exoplatform/chat/ChatTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/ChatTestCase.java
@@ -1,5 +1,6 @@
 package org.exoplatform.chat;
 
+import org.exoplatform.addons.chat.utils.ChatRoomUtils;
 import org.exoplatform.chat.bootstrap.ServiceBootstrap;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.model.NotificationSettingsBean;
@@ -17,14 +18,26 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.simple.JSONObject;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.ArgumentMatchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ChatRoomUtils.class)
 public class ChatTestCase extends AbstractChatTestCase
 {
   @Before
   public void setUp()
   {
+    PowerMockito.mockStatic(ChatRoomUtils.class);
+    when(ChatRoomUtils.getUserAvatar(ArgumentMatchers.anyString())).thenReturn("userAvatar");
+    when(ChatRoomUtils.getUserAvatar(ArgumentMatchers.anyString())).thenReturn("spaceAvatar");
+
     List<String> users = new ArrayList<String>();
     users.add("benjamin");
     users.add("john");
@@ -351,7 +364,6 @@ public class ChatTestCase extends AbstractChatTestCase
     ServiceBootstrap.getUserService().addTeamRoom(user, room1);
     ServiceBootstrap.getUserService().addTeamRoom(user, room2);
     ServiceBootstrap.getUserService().addTeamRoom(user, room3);
-
     RoomsBean roomsBean = ServiceBootstrap.getChatDataStorage().getUserRooms("benjamin", new ArrayList<>(),null, 0,20, notificationService, tokenService);
     assertEquals("Should have 8 rooms", 8, roomsBean.getRooms().size());
     int teamsRooms=0, spacesRooms =0, usersRooms =0;
@@ -435,6 +447,7 @@ public class ChatTestCase extends AbstractChatTestCase
 
 
     String spaceId1 = chatService.getSpaceRoom("test_space");
+
     chatService.write("foo", "benjamin", spaceId1, "false");
 
     String spaceId2 = chatService.getSpaceRoom("test_space_2");

--- a/server-embedded/src/test/java/org/exoplatform/chat/SpaceTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/SpaceTestCase.java
@@ -1,10 +1,12 @@
 package org.exoplatform.chat;
 
 import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.exoplatform.addons.chat.utils.ChatRoomUtils;
 import org.exoplatform.chat.bootstrap.ServiceBootstrap;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.model.SpaceBean;
@@ -13,12 +15,23 @@ import org.exoplatform.chat.services.mongodb.UserMongoDataStorage;
 import org.exoplatform.chat.utils.ChatUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ChatRoomUtils.class)
 public class SpaceTestCase extends AbstractChatTestCase
 {
   @Before
   public void setUp()
   {
+    PowerMockito.mockStatic(ChatRoomUtils.class);
+    when(ChatRoomUtils.getUserAvatar(ArgumentMatchers.anyString())).thenReturn("userAvatar");
+    when(ChatRoomUtils.getUserAvatar(ArgumentMatchers.anyString())).thenReturn("spaceAvatar");
+
     ConnectionManager.getInstance().getDB().getCollection(UserMongoDataStorage.M_USERS_COLLECTION).drop();
     ServiceBootstrap.getUserService().addUserFullName("benjamin", "Benjamin Paillereau");
     ServiceBootstrap.getUserService().addUserEmail("benjamin", "bpaillereau@exoplatform.com");

--- a/server-embedded/src/test/java/org/exoplatform/chat/UserTestCase.java
+++ b/server-embedded/src/test/java/org/exoplatform/chat/UserTestCase.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+import org.exoplatform.addons.chat.utils.ChatRoomUtils;
 import org.exoplatform.chat.bootstrap.ServiceBootstrap;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.model.UserBean;
@@ -13,10 +15,16 @@ import org.exoplatform.chat.services.mongodb.UserMongoDataStorage;
 import org.exoplatform.chat.utils.PropertyManager;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.List;
-
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ChatRoomUtils.class)
 public class UserTestCase extends AbstractChatTestCase
 {
   String username = "benjamin";
@@ -24,6 +32,10 @@ public class UserTestCase extends AbstractChatTestCase
   @Before
   public void setUp()
   {
+    PowerMockito.mockStatic(ChatRoomUtils.class);
+    when(ChatRoomUtils.getUserAvatar(ArgumentMatchers.anyString())).thenReturn("userAvatar");
+    when(ChatRoomUtils.getUserAvatar(ArgumentMatchers.anyString())).thenReturn("spaceAvatar");
+
     ConnectionManager.getInstance().getDB().getCollection(UserMongoDataStorage.M_USERS_COLLECTION).drop();
   }
 

--- a/services/src/main/java/org/exoplatform/addons/chat/api/UserRestService.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/api/UserRestService.java
@@ -23,6 +23,7 @@ import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.manager.RelationshipManager;
@@ -303,7 +304,11 @@ public class UserRestService implements ResourceContainer {
       chatCometDServerUrl = "/cometd/cometd";
     }
     String userStatus = ServerBootstrap.getStatus(currentUsername, token, currentUsername);
-
+    String avatarUrl = "";
+    Profile profile = userIdentity.getProfile();
+    if (profile != null) {
+      avatarUrl = profile.getAvatarUrl();
+    }
     JSONObject userSettings = new JSONObject();
     userSettings.put("username", currentUsername);
     userSettings.put("token", token);
@@ -317,6 +322,7 @@ public class UserRestService implements ResourceContainer {
     userSettings.put("chatPage", chatPage);
     userSettings.put("offlineDelay", userStateService.getDelay());
     userSettings.put("wsEndpoint", chatCometDServerUrl);
+    userSettings.put("avatarUrl", avatarUrl);
 
     int uploadLimitInMB = 0;
     boolean canUploadFiles = getDocumentService() != null;

--- a/services/src/main/java/org/exoplatform/addons/chat/utils/ChatRoomUtils.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/utils/ChatRoomUtils.java
@@ -1,0 +1,39 @@
+package org.exoplatform.addons.chat.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.SpaceUtils;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+public class ChatRoomUtils {
+
+    public static String getUserAvatar(String userName) {
+        IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+        if (StringUtils.isNotBlank(userName)) {
+            try {
+                Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
+                if (identity != null) {
+                    Profile profile = identity.getProfile();
+                    return profile.getAvatarUrl();
+                }
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public static String getSpaceAvatar(String prettyName) {
+        SpaceService spaceService = SpaceUtils.getSpaceService();
+        Space space = spaceService.getSpaceByPrettyName(prettyName);
+        if (space != null) {
+            return space.getAvatarUrl();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
**ISSUE** : when selecting a room in the full chat application and than select a second room, the room details always show the first selected room avatar because of the render before the promise resolving.
**FIX**: refactor the room avatar retrieving in the chat app by replacing the sync front rest calls by a retrieving in the back-end.