### PR TITLE
Task-50728: Wrong notification number is displayed in chat drawer when user sends a message 

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -495,24 +495,15 @@ export default {
         }
         foundContact.lastMessage = message.data;
         foundContact.timestamp = message.ts;
-        if (this.selected){
-          if (this.selected.room !== foundContact.room || this.mq === 'mobile') {
-            const msgId = message.msgId && typeof message.msgId !== 'undefined' ? message.msgId : message.data.msgId;
-            if (this.pushObjectIfNotExists(this.unreadMessages, {'msgId': msgId, 'room': room})) {
-              foundContact.unreadTotal++;
-            }
-          }
-        } else {
-          foundContact.unreadTotal ++;
-        }
       } else {
         chatServices.getRoomDetail(eXo.chat.userSettings, room).then((contact) => {
           if (contact && contact.user && contact.user.length && contact.user !== 'undefined') {
-            contact.unreadTotal = 1;
             this.contactsToDisplay.unshift(contact);
           }
         });
       }
+      this.$emit('refresh-contacts', true);
+      this.$forceUpdate();
     },
     messageSent(event) {
       const message = event.detail;

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -273,7 +273,6 @@ export default {
       const totalUnreadMsg = e.detail ? e.detail.data.totalUnreadMsg : e.totalUnreadMsg;
       if (totalUnreadMsg >= 0) {
         this.totalUnreadMsg = totalUnreadMsg;
-        this.refreshContacts(true);
       }
     },
     userStatusChanged(e) {


### PR DESCRIPTION
Prior this change, a wrong notification number is displayed in chat drawer when user sends a message , this is due to updating the number of unread messages twice