### PR TITLE
TASK-45314: Fix link issue in Chat

### DIFF
--- a/application/src/main/webapp/vue-app/messageFilter.js
+++ b/application/src/main/webapp/vue-app/messageFilter.js
@@ -7,7 +7,7 @@ export default function(msg, highlight, emojis) {
 
   lines.forEach( (line, index) => {
     line = $('<div />').html(line).text();
-    const words = line.split(' ');
+    const words = line.split(/(?:<br\s*\/?>|\s|&nbsp;)+/gi);
     words.forEach(w => {
       // check link
       if (w.indexOf('http:') === 0 || w.indexOf('https:') === 0 || w.indexOf('ftp:') === 0) {


### PR DESCRIPTION
*if a link is preceded with some characters the protocol is removed
*if a break line is performed after a link and then a text is written that text will be considered as a link
*if 2 links or more are inserted in the same message an overloab between them