### PR TITLE
Implement a chat room silence option (#396) (#398)

### DIFF
--- a/application/src/main/webapp/vue-app/chatConstants.js
+++ b/application/src/main/webapp/vue-app/chatConstants.js
@@ -93,6 +93,7 @@ export const chatConstants = {
   EVENT_MESSAGE_UPDATED: 'exo-chat-message-updated',
   EVENT_MESSAGE_STATISTIC: 'exo-statistic-message',
   EVENT_GLOBAL_UNREAD_COUNT_UPDATED: 'exo-chat-notification-count-updated',
+  ROOM_NOTIFICATION_SETTINGS_UPDATED: 'exo-chat-room-notification-settings-updated',
   EVENT_ROOM_PARTICIPANTS_LOADED: 'exo-chat-participants-loaded',
   EVENT_ROOM_DELETED: 'exo-chat-room-deleted',
   EVENT_ROOM_FAVORITE_ADDED: 'exo-chat-room-favorite-added',

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -3,6 +3,7 @@
     <div class="uiChatLeftContainer">
       <div class="userDetails">
         <exo-chat-contact
+          :contact-room-id="selectedContact.room"
           :user-name="userSettings.username"
           :name="userSettings.fullName"
           :status="userSettings.status"
@@ -38,9 +39,13 @@
         @contact-selected="setSelectedContact"
         @refresh-contacts="refreshContacts($event)" />
     </div>
-    <div v-show="(selectedContact && (selectedContact.room || selectedContact.user)) || mq === 'mobile'" class="uiGlobalRoomsContainer">
+    <div
+      v-show="(selectedContact && (selectedContact.room || selectedContact.user)) || mq === 'mobile'"
+      class="uiGlobalRoomsContainer"
+      role="main">
       <exo-chat-room-detail
         v-if="Object.keys(selectedContact).length !== 0"
+        :is-room-notification-silence="isSelectedRoomSilence"
         :contact="selectedContact"
         @back-to-contact-list="conversationArea = false" />
       <div class="room-content">
@@ -104,6 +109,7 @@
 import * as chatServices from '../chatServices';
 import * as chatWebStorage from '../chatWebStorage';
 import * as chatWebSocket from '../chatWebSocket';
+import * as desktopNotification from '../desktopNotification';
 import {chatConstants} from '../chatConstants';
 import {installExtensions} from '../extension';
 
@@ -145,6 +151,9 @@ export default {
     };
   },
   computed: {
+    isSelectedRoomSilence() {
+      return this.selectedContact && desktopNotification.isRoomNotificationSilence(this.selectedContact.room) || this.selectedContact.isRoomSilent;
+    },
     showMobileConversations() {
       return this.mq === 'mobile' && this.conversationArea === true ? true : false;
     },
@@ -211,7 +220,11 @@ export default {
         }
       }
 
-      const totalUnreadMsg = Math.abs(chatRoomsData.unreadOffline) + Math.abs(chatRoomsData.unreadOnline) + Math.abs(chatRoomsData.unreadSpaces) + Math.abs(chatRoomsData.unreadTeams);
+      const totalUnreadMsg = (Math.abs(chatRoomsData.unreadOffline)
+              + Math.abs(chatRoomsData.unreadOnline)
+              + Math.abs(chatRoomsData.unreadSpaces)
+              + Math.abs(chatRoomsData.unreadTeams))
+          - Number(chatRoomsData.unreadSilentRooms);
       chatServices.updateTotalUnread(totalUnreadMsg);
     },
     setSelectedContact(selectedContact) {

--- a/application/src/main/webapp/vue-app/components/ExoChatContact.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContact.vue
@@ -54,6 +54,25 @@
         v-if="mq === 'mobile' && list && lastMessage || chatDrawerContact"
         :class="chatDrawerContact ? 'lastMessageDrawer last-message' : 'last-message' "></div>
     </div>
+    <div
+      v-if="!isRoomSilent && unreadTotal > 0 && unreadTotal <= maxShowUnread"
+      class="unreadMessages">
+      {{ unreadTotal }}
+    </div>
+    <div
+      v-if="!isRoomSilent && unreadTotal > maxShowUnread"
+      class="unreadMessages maxUnread">
+      +{{ maxShowUnread }}
+    </div>
+    <div>
+      <v-icon
+        color="red darken-2"
+        dense
+        class="ml-2 mb-1"
+        v-if="isRoomSilent">
+        mdi-volume-off
+      </v-icon>
+    </div>
   </div>
 </template>
 
@@ -132,7 +151,19 @@ export default {
     chatDrawerContact: {
       type: Boolean,
       default: false
-    }
+    },
+    contactRoomId: {
+      type: String,
+      default: null
+    },
+    unreadTotal: {
+      type: Number,
+      default: null
+    },
+    isRoomSilent: {
+      type: Boolean,
+      default: false
+    },
   },
   data: function() {
     return {
@@ -152,6 +183,7 @@ export default {
         invisible: this.$t('exoplatform.chat.invisible'),
       },
       avatarUrl: '',
+      maxShowUnread: 99
     };
   },
   computed: {
@@ -193,7 +225,7 @@ export default {
         return getSpaceProfileLink(this.groupId, this.prettyName);
       }
       return '#';
-    }
+    },
   },
   created() {
     document.addEventListener(chatConstants.EVENT_DISCONNECTED, this.setOffline);

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -87,6 +87,9 @@
             :group-id="contact.groupId"
             :name="contact.fullName"
             :status="contact.status"
+            :unread-total="contact.unreadTotal"
+            :contact-room-id="contact.room"
+            :is-room-silent="contact.isRoomSilent"
             :last-message="getLastMessage(contact.lastMessage, contact.type)">
             <div
               v-if="mq === 'mobile'"
@@ -94,8 +97,6 @@
               class="uiIcon favorite"></div>
             <div v-if="mq === 'mobile' || drawerStatus" :class="[drawerStatus ? 'last-message-time-drawer last-message-time' : 'last-message-time']">{{ getLastMessageTime(contact) }}</div>
           </exo-chat-contact>
-          <div v-if="contact.unreadTotal > 0 && contact.unreadTotal <= 99" class="unreadMessages">{{ contact.unreadTotal }}</div>
-          <div v-if="contact.unreadTotal > 99" class="unreadMessages maxUnread">+99</div>
           <i
             v-exo-tooltip.top.body="$t('exoplatform.chat.msg.notDelivered')"
             v-if="!drawerStatus"
@@ -175,9 +176,11 @@ import * as chatServices from '../chatServices';
 import * as chatWebStorage from '../chatWebStorage';
 import * as chatWebSocket from '../chatWebSocket';
 import * as chatTime from '../chatTime';
-import {chatConstants} from '../chatConstants';
+import * as desktopNotification from '../desktopNotification';
 
+import {chatConstants} from '../chatConstants';
 import {composerApplications} from '../extension';
+
 
 export default {
   props: {
@@ -283,7 +286,7 @@ export default {
       contactsToDisplay: [],
       inactive: this.$t('exoplatform.chat.inactive'),
       external: this.$t('exoplatform.chat.external'),
-      nbrePages: 0
+      nbrePages: 0,
     };
   },
   computed: {
@@ -294,6 +297,12 @@ export default {
       const sortedContacts = this.contacts.slice(0).filter(contact => (contact.room || contact.user) && contact.fullName);
       if (this.sortFilter === 'Unread') {
         sortedContacts.sort(function(a, b){
+          if (desktopNotification.isRoomNotificationSilence(b.room) && a.unreadTotal !== 0) {
+            return -1;
+          }
+          if (desktopNotification.isRoomNotificationSilence(b.room) && a.unreadTotal === 0) {
+            return 0;
+          }
           const unreadTotal = b.unreadTotal - a.unreadTotal;
           if (unreadTotal === 0) {
             return b.timestamp - a.timestamp;
@@ -302,6 +311,12 @@ export default {
         });
       } else {
         sortedContacts.sort(function(a, b){
+          if (desktopNotification.isRoomNotificationSilence(b.room) && a.unreadTotal !== 0) {
+            return -1;
+          }
+          if (desktopNotification.isRoomNotificationSilence(b.room) && a.unreadTotal === 0) {
+            return 0;
+          }
           return b.timestamp - a.timestamp;
         });
       }
@@ -309,7 +324,7 @@ export default {
     },
     hasMoreContacts() {
       return Math.floor(this.filteredContacts.length / chatConstants.ROOMS_PER_PAGE) > this.nbrePages;
-    }
+    },
   },
   watch: {
     contacts() {
@@ -348,6 +363,7 @@ export default {
     document.addEventListener(chatConstants.ACTION_ROOM_SELECT, this.selectContact);
     document.addEventListener(chatConstants.EVENT_ROOM_SELECTION_CHANGED, this.contactChanged);
     document.addEventListener(chatConstants.EVENT_MESSAGE_NOT_SENT, this.messageNotSent);
+    document.addEventListener(chatConstants.ROOM_NOTIFICATION_SETTINGS_UPDATED, this.refreshNotificationSettings);
     this.typeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
     this.sortFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_SORT_FILTER, chatConstants.SORT_FILTER_DEFAULT);
     this.contactsToDisplay = this.contacts.slice();
@@ -374,8 +390,21 @@ export default {
     document.removeEventListener(chatConstants.ACTION_ROOM_SELECT, this.selectContact);
     document.removeEventListener(chatConstants.EVENT_ROOM_SELECTION_CHANGED, this.contactChanged);
     document.removeEventListener(chatConstants.EVENT_MESSAGE_NOT_SENT, this.messageNotSent);
+    document.removeEventListener(chatConstants.ROOM_NOTIFICATION_SETTINGS_UPDATED, this.refreshNotificationSettings);
   },
   methods: {
+    refreshNotificationSettings(event) {
+      const roomId = event.detail.data.targetRoom;
+      this.filteredContacts.filter(contact => {
+        if (contact.room === roomId) {
+          if (event.detail.data.notificationTrigger === 'silence') {
+            contact.isRoomSilent = true;
+          } else {
+            contact.isRoomSilent = false;
+          }
+        }
+      });
+    },
     normalizeText(s) {
       return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
     },
@@ -728,7 +757,7 @@ export default {
         return chatServices.getSpaceProfileLink(this.contactMenu.fullName);
       }
       return '#';
-    },
+    }
   }
 };
 </script>

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -236,7 +236,9 @@ export default {
         userSettings => this.initSettings(userSettings),
         chatRoomsData => {
           this.initChatRooms(chatRoomsData);
-          const totalUnreadMsg = Math.abs(Number(chatRoomsData.unreadOffline) + Number(chatRoomsData.unreadSpaces)+Number(chatRoomsData.unreadOnline) + Number(chatRoomsData.unreadTeams));
+          const totalUnreadMsg = Math.abs(Number(chatRoomsData.unreadOffline) +
+              Number(chatRoomsData.unreadSpaces) + Number(chatRoomsData.unreadOnline) +
+              Number(chatRoomsData.unreadTeams)) - Number(chatRoomsData.unreadSilentRooms);
           if (totalUnreadMsg >= 0) {
             this.totalUnreadMsg = totalUnreadMsg;
           }

--- a/common/src/main/java/org/exoplatform/chat/model/RealTimeMessageBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/RealTimeMessageBean.java
@@ -26,6 +26,7 @@ public class RealTimeMessageBean {
     FAVORITE_REMOVED("favorite-removed"),
     ROOM_SETTINGS_UPDATED("room-settings-updated"),
     NOTIFICATION_COUNT_UPDATED("notification-count-updated"),
+    ROOM_NOTIFICATION_SETTINGS_UPDATED("room-notification-settings-updated"),
     LOGOUT_SENT("logout-sent");
 
     private final String eventType;

--- a/common/src/main/java/org/exoplatform/chat/model/RoomBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/RoomBean.java
@@ -45,6 +45,7 @@ public class RoomBean implements Comparable<RoomBean>
   long timestamp = -1;
   org.json.JSONObject lastMessage;
   String groupId;
+  private boolean isRoomSilent = false;
 
   public String getPrettyName() {
     return prettyName;
@@ -200,6 +201,14 @@ public class RoomBean implements Comparable<RoomBean>
     this.enabledRoom = enabledRoom;
   }
 
+  public boolean isRoomSilent() {
+    return isRoomSilent;
+  }
+
+  public void setRoomSilent(boolean roomSilent) {
+    isRoomSilent = roomSilent;
+  }
+
   @SuppressWarnings("unchecked")
   public JSONObject toJSONObject() {
     JSONObject obj = new JSONObject();
@@ -222,6 +231,7 @@ public class RoomBean implements Comparable<RoomBean>
     if(this.getGroupId() != null && !this.getGroupId().isEmpty()) {
       obj.put("groupId", this.getGroupId());
     }
+    obj.put("isRoomSilent", this.isRoomSilent());
     if (this.getAdmins() != null) {
       try {
         obj.put("admins", new JSONArray(this.getAdmins()));

--- a/common/src/main/java/org/exoplatform/chat/model/RoomsBean.java
+++ b/common/src/main/java/org/exoplatform/chat/model/RoomsBean.java
@@ -12,6 +12,7 @@ public class RoomsBean {
   int unreadSpaces = 0;
   int unreadTeams = 0;
   int roomsCount = 0;
+  int unreadSilentRooms = 0;
 
   public List<RoomBean> getRooms() {
     return rooms;
@@ -61,6 +62,14 @@ public class RoomsBean {
     this.roomsCount = roomsCount;
   }
 
+  public int getUnreadSilentRooms() {
+    return unreadSilentRooms;
+  }
+
+  public void setUnreadSilentRooms(int unreadSilentRooms) {
+    this.unreadSilentRooms = unreadSilentRooms;
+  }
+
   public String roomsToJSON()
   {
     StringBuilder sb = new StringBuilder();
@@ -70,6 +79,7 @@ public class RoomsBean {
     sb.append("\"unreadSpaces\": \"").append(unreadSpaces).append("\",");
     sb.append("\"unreadTeams\": \"").append(unreadTeams).append("\",");
     sb.append("\"roomsCount\": \"").append(roomsCount).append("\",");
+    sb.append("\"unreadSilentRooms\": \"").append(unreadSilentRooms).append("\",");
     sb.append("\"rooms\": [");
     boolean first=true;
     for (RoomBean roomBean:this.getRooms()) {

--- a/common/src/main/java/org/exoplatform/chat/services/NotificationService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/NotificationService.java
@@ -45,4 +45,5 @@ public interface NotificationService
 
   public int getNumberOfUnreadNotifications();
 
+  public boolean isRoomSilentForUser(String user, String roomId);
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -642,6 +642,19 @@ public class ChatServer
 
     try{
       userService.setRoomNotificationTrigger(user, room, notifCondition, notifConditionType, time);
+      Map<String, Object> data = new HashMap<>();
+
+      data.put("notificationTrigger", notifConditionType);
+      data.put("targetRoom", room);
+
+      // Deliver the saved message to sender's subscribed channel itself.
+      RealTimeMessageBean messageBean = new RealTimeMessageBean(
+              RealTimeMessageBean.EventType.ROOM_NOTIFICATION_SETTINGS_UPDATED,
+              null,
+              user,
+              null,
+              data);
+      realTimeMessageService.sendMessage(messageBean, user);
     } catch(Exception e) {
     }
 
@@ -979,7 +992,8 @@ public class ChatServer
     if (!detailed)
     {
       // GETTING TOTAL NOTIFICATION WITHOUT DETAILS
-      totalUnread = notificationService.getUnreadNotificationsTotal(user);
+      List<NotificationBean> notificationBeans = notificationService.getUnreadNotifications(user, userService);
+      totalUnread = notificationBeans.size();
       if (userService.isAdmin(user)) {
         totalUnread += notificationService.getUnreadNotificationsTotal(UserService.SUPPORT_USER);
       }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/ChatServiceImpl.java
@@ -128,10 +128,15 @@ public class ChatServiceImpl implements ChatService
                 mentionData);
         realTimeMessageService.sendMessage(mentionMessage, mentionedUsers);
       }
+      List<String> silentReceivers = new ArrayList<>();
+      usersToBeNotified.stream().filter( name -> notificationService.isRoomSilentForUser(name, room))
+              .forEach(silentReceivers::add);
+
       JSONObject data = msg.toJSONObject();
       data.put("clientId", clientId);
       data.put("roomType", roomType);
       data.put("room", room);
+      data.put("silentReceivers", silentReceivers);
       if (ChatService.TYPE_ROOM_USER.equals(roomType)) {
         data.put("roomDisplayName", user.getFullname());
       } else {

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/NotificationMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/NotificationMongoDataStorage.java
@@ -23,10 +23,17 @@ import com.mongodb.*;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.model.NotificationBean;
+import org.exoplatform.chat.model.NotificationSettingsBean;
 import org.exoplatform.chat.model.RoomBean;
 import org.exoplatform.chat.services.ChatService;
 import org.exoplatform.chat.services.NotificationDataStorage;
 import org.exoplatform.chat.services.UserService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.json.JSONException;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
@@ -39,6 +46,8 @@ import java.util.List;
 @Singleton
 public class NotificationMongoDataStorage implements NotificationDataStorage
 {
+  private static final Log LOG = ExoLogger.getLogger(NotificationMongoDataStorage.class);
+
   private DB db()
   {
     return ConnectionManager.getInstance().getDB();
@@ -140,16 +149,46 @@ public class NotificationMongoDataStorage implements NotificationDataStorage
         notificationBean.setOptions(doc.get("options").toString());
       }
       RoomBean roomBean = userService.getRoom(user, notificationBean.getCategoryId());
-      notificationBean.setRoomType(roomBean.getType());
-      if (roomBean.getType().equals(ChatService.TYPE_ROOM_SPACE) || roomBean.getType().equals(ChatService.TYPE_ROOM_TEAM)) {
-        notificationBean.setRoomDisplayName(roomBean.getFullName());
+      if (roomBean != null) {
+        notificationBean.setRoomType(roomBean.getType());
+        if (roomBean.getType().equals(ChatService.TYPE_ROOM_SPACE) || roomBean.getType().equals(ChatService.TYPE_ROOM_TEAM)) {
+          notificationBean.setRoomDisplayName(roomBean.getFullName());
+        }
       }
       notificationBean.setLink(doc.get("link").toString());
 
       notifications.add(notificationBean);
     }
+    notifications = filterNotifications(notifications, userService, user);
 
     return notifications;
+  }
+
+  private List<NotificationBean> filterNotifications(List<NotificationBean> notifications, UserService userService, String receiver) {
+    List<NotificationBean> notificationBeans = new ArrayList<>();
+    try {
+      if (notifications != null && !notifications.isEmpty()) {
+        NotificationSettingsBean settings = userService.getUserDesktopNotificationSettings(receiver);
+        if (settings != null && settings.getEnabledRoomTriggers() != null) {
+          String bean = settings.getEnabledRoomTriggers();
+          JSONParser parser = new JSONParser();
+          JSONObject json = (JSONObject) parser.parse(bean);
+          for (NotificationBean notification : notifications) {
+            JSONObject roomSettings = (JSONObject) json.get(notification.getCategoryId());
+            if (roomSettings != null && roomSettings.get("notifCond") != null && roomSettings.get("notifCond").equals("silence")
+                    && notification.getCategory().equals("room")) {
+              continue;
+            }
+            notificationBeans.add(notification);
+          }
+        } else {
+          return notifications;
+        }
+      }
+    } catch (ParseException | JSONException e) {
+      LOG.error("error parsing chat notifications data", e);
+    }
+    return notificationBeans;
   }
 
   public int getUnreadNotificationsTotal(String user)


### PR DESCRIPTION
MAINT-36177: relocate the silent room over the contact list when receiving a message but with lower piority than normal rooms (#376)

Relocate the silent room over the contact list when receiving a message but with lower priority than normal rooms

MAINT-36177: Fix minichat notifications count when no user desktop notification settings is set (#379)

Fix minichat notifications count when no user desktop notification settings is set

MAINT-36177: chat silent option improvments