### PR TITLE
Task-42075:Long message display problem in the edit message pop-up in chat

### DIFF
--- a/application/src/main/webapp/css/components/chatMessage.less
+++ b/application/src/main/webapp/css/components/chatMessage.less
@@ -197,7 +197,10 @@
   width: 96%;
   border: Solid 2px @borderColor;
   box-shadow: none;
-  height: 80px;
+  height: 80px;outline: none;
+  overflow:scroll;
+  overflow-x:hidden;
+  max-height:200px;
   &:focus {
     border-color: @focusInputColor;
     outline: none;


### PR DESCRIPTION
Problem: Long message display in the edit pop-up is strange, the save and cancel buttons are displayed above the message (inside the message composer).
Fix: The save and cancel buttons are in the bottom of the pop-up (not inside the message composer).