### PR TITLE
MAINT-51782: Fix and improve chat rooms sorting when receive messages in normal and silent rooms  on sort by recent and unread messages

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -102,6 +102,7 @@
         <template slot="content">
           <div :class="!selectedContact ? 'contentDrawer ' : 'contentDrawerOfList'">
             <exo-chat-contact-list
+              :is-chat-drawer="true"
               v-show="!selectedContact && contactList.length > 0"
               :search-word="searchTerm"
               :drawer-status="showChatDrawer"


### PR DESCRIPTION
Before this fix, When receive messages in normal an silent rooms the sort of the chat discussion wasn't stable when giving priority to normal rooms and sometimes a silent rooms get relocated over a normal room. **Also allow sort only by recent messages filter in the chat drawer**
