### PR TITLE
deleted the condition where tagging other users in a comment are restricted only to the desktop

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -138,7 +138,7 @@ export default {
   },
   updated() {
     if (this.contact) {
-      if (this.contact.isEnabledUser === 'true' || this.contact.isEnabledUser === 'null') { // set autofocus only for enabled contact on desktop
+      if (this.contact.isEnabledUser === 'true' || this.contact.isEnabledUser === 'null') {
         this.$nextTick(() => {
           this.$refs.messageComposerArea.focus();
           this.composerApplications.forEach(application => {

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -138,7 +138,7 @@ export default {
   },
   updated() {
     if (this.contact) {
-      if (this.mq === 'desktop' && (this.contact.isEnabledUser === 'true' || this.contact.isEnabledUser === 'null')) { // set autofocus only for enabled contact on desktop
+      if (this.contact.isEnabledUser === 'true' || this.contact.isEnabledUser === 'null') { // set autofocus only for enabled contact on desktop
         this.$nextTick(() => {
           this.$refs.messageComposerArea.focus();
           this.composerApplications.forEach(application => {


### PR DESCRIPTION
ISSUE: TASK#42361 Mentioning in a chat is not possible when using eXo mobile
FIX: removed the condition where tagging other users are restricted to the desktop