### PR TITLE
Task-49792 : fix chatServer build after log4j remove

### DIFF
--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -94,6 +94,7 @@
     <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-testing</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>


### PR DESCRIPTION
before this fix, the chatServer application was build with all jar related to commons-testing library.
this fix add the scope test for this library to not get all dependencies in the war