### PR TITLE
task-54042: Mention doesn't work on chat

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -145,9 +145,9 @@ export default {
           this.composerApplications.forEach(application => {
             if (application.mount) {
               application.mount($, chatServices);
-              this.initSuggester();
             }
           });
+          this.initSuggester();
         });
       }
     }


### PR DESCRIPTION
Problem: in a space/chatroom no suggestion will be displayed after typing @ + some characters
Before this fix the initSuggester function was called in a loop on chat application extension. For each application, if the app have the mount function, we call it, then initSuggester. 
Only one application have the mount function : addTask. This application was removed few day ago. So the initSuggester was no more called.
This fix move the initSuggester so that it is called event if there is no application.