### PR TITLE
task-54827: added the possibility to open specific chat rooms from external links when using a mobile device

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -213,11 +213,9 @@ export default {
       this.addRooms(chatRoomsData.rooms);
       this.contactsSize = chatRoomsData.roomsCount;
 
-      if (this.mq !== 'mobile') {
-        const selectedRoom = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_LAST_SELECTED_ROOM);
-        if (selectedRoom) {
-          this.setSelectedContact(selectedRoom);
-        }
+      const selectedRoom = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_LAST_SELECTED_ROOM);
+      if (selectedRoom) {
+        this.setSelectedContact(selectedRoom);
       }
 
       const totalUnreadMsg = (Math.abs(chatRoomsData.unreadOffline)


### PR DESCRIPTION
ISSUE: cannot open specific chat rooms from external links such as  
http://localhost:8080/portal/dw/chat?roomId=115e6cdd93454aa571548a9a23b3d8dbfcc500bf  when using a mobile device.
This issue was discovered when the new push notification for chat messaging could not open the exact chat room,
we are only redirected to the chat application page containing the chat contact list 

FIX: removed the constraint to load the chat room for only non mobile devices