### PR TITLE
task-54908: when the user clicks on a chat push notification hes redirected the the appropriate chat room

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -218,6 +218,10 @@ export default {
   created() {
     chatServices.getUserSettings(this.userSettings.username).then(userSettings => {
       this.initSettings(userSettings);
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.has('pushNotifRoomid')){
+        this.openRoomWithId(urlParams.get('pushNotifRoomid'));
+      }
     });
     document.addEventListener(chatConstants.EVENT_MESSAGE_RECEIVED, this.messageReceived);
     document.addEventListener(chatConstants.EVENT_ROOM_UPDATED, this.roomUpdated);
@@ -511,6 +515,16 @@ export default {
           }
           action.init(container, eXo.chat);
         }
+      }
+    },
+    openRoomWithId(roomId){
+      chatServices.getRoomDetail(this.userSettings,roomId).then(room => {
+        this.openDrawer();
+        this.setSelectedContact(room);
+      }).catch(()=>{this.openDrawer();});
+      const tiptip = document.getElementById('tiptip_holder');
+      if (tiptip) {
+        tiptip.style.display = 'none';
       }
     }
   }

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -219,8 +219,8 @@ export default {
     chatServices.getUserSettings(this.userSettings.username).then(userSettings => {
       this.initSettings(userSettings);
       const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.has('pushNotifRoomid')){
-        this.openRoomWithId(urlParams.get('pushNotifRoomid'));
+      if (urlParams.has('chatRoomId')){
+        this.openRoomWithId(urlParams.get('chatRoomId'));
       }
     });
     document.addEventListener(chatConstants.EVENT_MESSAGE_RECEIVED, this.messageReceived);

--- a/services/src/main/java/org/exoplatform/addons/chat/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/utils/NotificationUtils.java
@@ -95,9 +95,9 @@ public class NotificationUtils {
         }
         String notificationURL = "";
         if (roomId != null) {
-            notificationURL = currentDomain + "portal/" + currentSite + "/chat?roomId=" + roomId;
+            notificationURL = currentDomain + "portal/" + currentSite + "/?pushNotifRoomid=" + roomId;
         } else {
-            notificationURL = currentDomain + "portal/" + currentSite + "/chat";
+            notificationURL = currentDomain + "portal/" + currentSite + "/?pushNotifRoomid";
         }
         return notificationURL;
     }

--- a/services/src/main/java/org/exoplatform/addons/chat/utils/NotificationUtils.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/utils/NotificationUtils.java
@@ -95,9 +95,9 @@ public class NotificationUtils {
         }
         String notificationURL = "";
         if (roomId != null) {
-            notificationURL = currentDomain + "portal/" + currentSite + "/?pushNotifRoomid=" + roomId;
+            notificationURL = currentDomain + "portal/" + currentSite + "/?chatRoomId=" + roomId;
         } else {
-            notificationURL = currentDomain + "portal/" + currentSite + "/?pushNotifRoomid";
+            notificationURL = currentDomain + "portal/" + currentSite + "/?chatRoomId";
         }
         return notificationURL;
     }


### PR DESCRIPTION
ISSUE: when the user clicks on a chat push notification (mention or message received) he's redirected to the chat application.
FIX: the user is now redirected to the chat room inside the chat drawer .
This fix is implemented by querying the site's url for a pushNotifRoomid parameter that provides the room's id, we then pass it to a chat service that uses this id to give us an object with the necessary properties that we use to open up the room.
As an extra measure of security,  if the room's id is not valid the user is simply redirected to the chat drawer. 