### PR TITLE
backport/task-54716: display the number of unread message below the time or date #461

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatContact.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContact.vue
@@ -56,12 +56,12 @@
     </div>
     <div
       v-if="!isRoomSilent && unreadTotal > 0 && unreadTotal <= maxShowUnread"
-      class="unreadMessages">
+      :class="['unreadMessages', {'mt-10':mq==='mobile'}]">
       {{ unreadTotal }}
     </div>
     <div
       v-if="!isRoomSilent && unreadTotal > maxShowUnread"
-      class="unreadMessages maxUnread">
+      :class="['unreadMessages', 'maxUnread', {'mt-10':mq==='mobile'}]">
       +{{ maxShowUnread }}
     </div>
     <div>

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -95,7 +95,11 @@
               v-if="mq === 'mobile'"
               :class="{'is-fav': contact.isFavorite}"
               class="uiIcon favorite"></div>
-            <div v-if="mq === 'mobile' || drawerStatus" :class="[drawerStatus ? 'last-message-time-drawer last-message-time' : 'last-message-time']">{{ getLastMessageTime(contact) }}</div>
+            <div
+              v-if="mq === 'mobile' || drawerStatus"
+              :class="[drawerStatus ? 'last-message-time-drawer last-message-time' : 'last-message-time']">
+              {{ getLastMessageTime(contact) }}
+            </div>
           </exo-chat-contact>
           <i
             v-exo-tooltip.top.body="$t('exoplatform.chat.msg.notDelivered')"


### PR DESCRIPTION
ISSUE: the element for the number of unread message in the contacts list overlaps the date element for that discussion
FIX:display the number of unread message below the date