### PR TITLE
Task-55822: decode special html characters to display the text with the appropriate format and style #474

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -723,6 +723,10 @@ export default {
       }
       return '';
     },
+    decodeHtml(input) {
+      const doc = new DOMParser().parseFromString(input, 'text/html');
+      return doc.documentElement.textContent;
+    },
     filterLastMessage(msg) {
       if (msg === chatConstants.DELETED_MESSAGE) {
         return this.$t('exoplatform.chat.deleted');
@@ -731,7 +735,7 @@ export default {
       if (msg.indexOf('<br/>') >= 0) {
         return msg.replace(msg.slice(msg.indexOf('<br/>')),'...');
       }
-      return msg;
+      return this.decodeHtml(msg);
     },
     contactStatusChanged(e) {
       const contactChanged = e.detail;


### PR DESCRIPTION
ISSUE: when tagging a user in a text message the greater than '>' and less than '<' characters are encoded with &\gt; and &\lt;
FIX: decode these character into '>' and '<' so that the string can be parsed as html
(cherry picked from commit 4a407f6d7cffe19695ab937b774e350ea7a51dc6)