### PR TITLE
Task-57294: wrong Labels displayed

### DIFF
--- a/services/src/main/resources/locale/portlet/chat/Resource_en.properties
+++ b/services/src/main/resources/locale/portlet/chat/Resource_en.properties
@@ -258,6 +258,7 @@ exoplatform.chat.spaceSettings.external.component.description=Enable space chat
 Notification.subject.ChatMentionNotificationPlugin=Chat mention
 Notification.ChatMentionNotificationPlugin.label.SayHello=Hello
 Notification.ChatMentionNotificationPlugin.label.footer=If you do not want to receive such notifications, <a target="_blank" class="notification_settings_url" href="{0}">click here</a> to change your notification settings.
+Notification.chat.button.tooltip=Chat
 # For UI
 UINotification.title.ChatMentionNotificationPlugin=Someone mentions me in chat
 UINotification.label.ChatMentionNotificationPlugin=Mention in chat


### PR DESCRIPTION
Problem: hovering the chat and edit layout , the labels aren't the right ones
Fix: I tried to modified the tooltip, labels to make them display correctly when hovering on them