### PR TITLE
TASK-57175: fix user can download files in a chat room even if the transfer rule to disable file downloads in set

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>application</artifactId>
   <packaging>war</packaging>

--- a/application/src/main/webapp/css/components/chatDrawer.less
+++ b/application/src/main/webapp/css/components/chatDrawer.less
@@ -10,7 +10,7 @@
       position: absolute;
       left: 21px ~'; /** orientation=lt */ ';
       right: 21px ~'; /** orientation=rt */ ';
-      top: -5px;
+      top: -9px;
       font-size: 12px;
       min-width: 20px;
       height: 20px;

--- a/application/src/main/webapp/css/components/contactList.less
+++ b/application/src/main/webapp/css/components/contactList.less
@@ -1,5 +1,5 @@
 /* contact list component */
-@selectedContactColor: #578DC9;
+@selectedContactColor: #476A9C;
 @currentContactMenuColor: #e6eef7;
 @contactFilterColor: #355788;
 @contactFilterPlaceHolderColor: #7a90b1;

--- a/application/src/main/webapp/css/components/roomDetail.less
+++ b/application/src/main/webapp/css/components/roomDetail.less
@@ -24,7 +24,7 @@
         &, ~ .dropdown-toggle {
           padding: 4px 10px;
           border-radius: 0;
-          border: 1px solid #578dc9;
+          border: 1px solid #476A9C;
           color: @primaryColor;
           background: none;
           [class*="Icon"]:before {

--- a/application/src/main/webapp/css/variables.less
+++ b/application/src/main/webapp/css/variables.less
@@ -4,7 +4,7 @@
 @defaultFontFamily: Helvetica, Arial, sans-serif;
 
 /* colors */
-@primaryColor: #578dc9;
+@primaryColor: #476A9C;
 @secondaryColor: #476a9c;
 @titleColor: #4d5466;
 @grayDark: #333;

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
@@ -27,8 +27,8 @@
       <div v-if="messageType === chatConstants.DELETED_MESSAGE" class="message-content">
         <em class="muted">{{ $t('exoplatform.chat.deleted') }}</em>
       </div>
-      <div v-else-if="messageOptionsType === chatConstants.FILE_MESSAGE" class="message-content">
-        <b>
+      <div v-else-if="messageOptionsType === chatConstants.FILE_MESSAGE"  class="message-content">
+        <b :style="!downloadEnabled ? 'pointer-events: none;' : '' ">
           <a :href="message.options.restPath" target="_blank">{{ message.options.title }}</a>
         </b>
         <span class="message-file-size">{{ message.options.sizeLabel }}</span>
@@ -257,6 +257,7 @@ export default {
       confirmOKMessage: '',
       confirmKOMessage: '',
       confirmAction(){return;},
+      downloadEnabled: true,
     };
   },
   computed: {
@@ -339,6 +340,7 @@ export default {
       'exo-chat-message-action-delete-requested',
       this.deleteMessage
     );
+    Vue.prototype.$transferRulesService.getTransfertRulesDownloadDocumentStatus().then(data=>{this.downloadEnabled = data;});
   },
   destroyed() {
     document.removeEventListener(

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
@@ -340,7 +340,7 @@ export default {
       'exo-chat-message-action-delete-requested',
       this.deleteMessage
     );
-    Vue.prototype.$transferRulesService.getTransfertRulesDownloadDocumentStatus().then(data=>{this.downloadEnabled = data;});
+    this.$transferRulesService?.getTransfertRulesDownloadDocumentStatus().then(enabled=> this.downloadEnabled = enabled);
   },
   destroyed() {
     document.removeEventListener(

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-common</artifactId>
   <name>eXo Add-on:: Chat Client Server Common</name>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-extension</artifactId>
   <packaging>war</packaging>

--- a/packaging/embedded-packaging/pom.xml
+++ b/packaging/embedded-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.addons.chat</groupId>
     <artifactId>packaging</artifactId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-embedded-packaging</artifactId>
   <packaging>pom</packaging>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <groupId>org.exoplatform.addons.chat</groupId>
   <artifactId>packaging</artifactId>
-  <version>3.4.x-SNAPSHOT</version>
+  <version>3.4.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: Chat Packaging</name>
   <description>Chat application packaging module</description>

--- a/packaging/standalone-client-packaging/pom.xml
+++ b/packaging/standalone-client-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.addons.chat</groupId>
     <artifactId>packaging</artifactId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-standalone-client-packaging</artifactId>
   <packaging>pom</packaging>

--- a/packaging/standalone-server-packaging/pom.xml
+++ b/packaging/standalone-server-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.addons.chat</groupId>
     <artifactId>packaging</artifactId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-standalone-server-packaging</artifactId>
   <packaging>pom</packaging>

--- a/packaging/standalone-server-tomcat-distrib/pom.xml
+++ b/packaging/standalone-server-tomcat-distrib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.exoplatform.addons.chat</groupId>
     <artifactId>packaging</artifactId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-standalone-server-tomcat-distrib</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.exoplatform.addons.chat</groupId>
   <artifactId>chat-application</artifactId>
-  <version>3.4.x-SNAPSHOT</version>
+  <version>3.4.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: Chat Application / Server</name>
   <description>Chat application and server developed with Juzu and MongoDB</description>
@@ -31,10 +31,10 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.gatein.portal.version>6.4.x-SNAPSHOT</org.exoplatform.gatein.portal.version>
-    <org.exoplatform.social.version>6.4.x-SNAPSHOT</org.exoplatform.social.version>
-    <addon.exo.ecms.version>6.4.x-SNAPSHOT</addon.exo.ecms.version>
-    <addon.exo.notes.version>1.2.x-SNAPSHOT</addon.exo.notes.version>
+    <org.exoplatform.gatein.portal.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.gatein.portal.version>
+    <org.exoplatform.social.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <addon.exo.ecms.version>6.4.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
+    <addon.exo.notes.version>1.2.x-maintenance-SNAPSHOT</addon.exo.notes.version>
   	<org.juzu.version>1.2.x-SNAPSHOT</org.juzu.version>
 
     <!-- TODO check dependencies from parent pom -->

--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-server-embedded</artifactId>
   <packaging>war</packaging>

--- a/server-standalone/pom.xml
+++ b/server-standalone/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-server-standalone</artifactId>
   <packaging>war</packaging>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>chat-application</artifactId>
     <groupId>org.exoplatform.addons.chat</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>chat-services</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
ISSUE: in  a chat room the user is able to download any uploaded files even if the transfer rule 'Suspend temporarily documents download' set by an administrator is enabled
FIX: if this rule is enabled the user cannot  download files already uploaded in a chat room