### PR TITLE
task-57412: Using ellipsis form in chat drawer title

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -21,7 +21,7 @@
         right
         @closed="resetSelectedContact">
         <template v-if="!showSearch" slot="title">
-          <div class="leftHeaderDrawer">
+          <div class="leftHeaderDrawer flex-shrink-1 text-truncate">
             <span v-if="!selectedContact && !showSearch" class="chatContactDrawer">
               <exo-chat-contact
                 :chat-drawer-contact="showChatDrawer"


### PR DESCRIPTION
Prior to this change, a long space name is badly displayed in the chat drawer.
After this change, we will be able to display the long space name in an ellipsis form.