### PR TITLE
TASK-57175: Disable download files in chat messages depends on transferRules settings

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageDetail.vue
@@ -50,7 +50,7 @@
                     <i class="uiIconSearch uiIconWhite"></i>
                   </a>
                 </p>
-                <p>
+                <p v-if="downloadDocumentEnabled">
                   <a :href="message.options.downloadLink" target="_blank">
                     <i class="uiIconDownload uiIconWhite"></i>
                   </a>
@@ -244,6 +244,10 @@ export default {
     hideTime: {
       type: Boolean,
       default: false
+    },
+    downloadDocumentEnabled: {
+      type: Boolean,
+      default: false,
     }
   },
   data: function() {

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageList.vue
@@ -29,6 +29,7 @@
           :hide-time="messageObj.hideTime"
           :hide-avatar="messageObj.hideAvatar"
           :mini-chat="miniChat"
+          :download-document-enabled="downloadDocumentEnabled"
           @edit-message="editMessage" />
       </div>
       <span v-show="!newMessagesLoading && (!messages || !messages.length)" class="text">{{ $t('exoplatform.chat.no.messages') }}</span>
@@ -104,7 +105,8 @@ export default {
       totalMessagesToLoad: 0,
       searchKeyword: '',
       windowFocused: true,
-      newMessagesLoading: false
+      newMessagesLoading: false,
+      downloadDocumentEnabled: false
     };
   },
   computed: {
@@ -145,6 +147,9 @@ export default {
 
     $(window).focus(this.chatFocused);
     $(window).blur(this.chatFocused);
+    this.$transferRulesService?.getTransfertRulesDownloadDocumentStatus().then(enabled => {
+      this.downloadDocumentEnabled = enabled;
+    });
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_MESSAGE_UPDATED, this.messageReceived);


### PR DESCRIPTION
Prior to this change, when send a document or any file via chat messages, the download option is always enabled what ever was the settings value of transfer rules.
This PR should check transferRules settings to enable or disable the download option in chat message