### PR TITLE
TASK-58840: Chat app button doesn't work on firefox.  (#519)

### DIFF
--- a/application/src/main/webapp/vue-app/chatButton/components/chatButton.vue
+++ b/application/src/main/webapp/vue-app/chatButton/components/chatButton.vue
@@ -1,20 +1,21 @@
 <template id="chatButtonApplication"> 
-<div class="VuetifyApp">
-  <div class="v-application miniChatDrawer v-application--is-ltr theme--light">
-  <div class="v-application--wrap">
-    <v-btn
-      id="btnChatButton"
-      class="dropdown-toggle"
-      :class="statusClass()"
-      title="chatButton"
-      icon>
-      <v-icon size="22" class="my-auto uiIconStatus icon-default-color fas fa-comments" />
-      <span :class="canShowOnSiteNotif() && totalUnreadMsg > 0 && totalUnreadMsg <= 99 ? '' : 'hidden'" class="notif-total badgeDefault badgePrimary mini">{{ totalUnreadMsg }}</span>
-      <span :class="canShowOnSiteNotif() && totalUnreadMsg > 99 ? '' : 'hidden'" class="notif-total badgeDefault badgePrimary mini max">+99</span>
-    </v-btn>
+  <div class="VuetifyApp">
+    <div class="v-application miniChatDrawer v-application--is-ltr theme--light">
+      <div class="v-application--wrap">
+        <v-btn
+          id="btnChatButton"
+          class="dropdown-toggle"
+          :class="statusClass()"
+          :title="$t('Notification.chat.button.tooltip')"
+          @click="openChatDrawer"
+          icon>
+          <v-icon size="22" class="my-auto uiIconStatus icon-default-color fas fa-comments" />
+          <span :class="canShowOnSiteNotif() && totalUnreadMsg > 0 && totalUnreadMsg <= 99 ? '' : 'hidden'" class="notif-total badgeDefault badgePrimary mini">{{ totalUnreadMsg }}</span>
+          <span :class="canShowOnSiteNotif() && totalUnreadMsg > 99 ? '' : 'hidden'" class="notif-total badgeDefault badgePrimary mini max">+99</span>
+        </v-btn>
+      </div>
+    </div>
   </div>
-  </div>
-</div>
 </template>
 <script>
 import * as chatServices from '../../chatServices';
@@ -79,6 +80,14 @@ export default {
       } else {
         return `user-${this.userSettings.status}`;
       }
+    },
+    openChatDrawer(event){
+      if (event){
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      document.dispatchEvent(new CustomEvent(chatConstants.ACTION_CHAT_OPEN_DRAWER));
+
     }
   }
 };

--- a/application/src/main/webapp/vue-app/chatButton/main.js
+++ b/application/src/main/webapp/vue-app/chatButton/main.js
@@ -1,10 +1,9 @@
 import app from './components/chatButton.vue';
 import '../components/initComponents';
+import {chatConstants} from '../chatConstants.js';
 // getting language of user
-const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';
-
-const resourceBundleName = 'locale.addon.Sample';
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/${resourceBundleName}-${lang}.json`;
+const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
+const url = `${chatConstants.PORTAL}/${chatConstants.PORTAL_REST}/i18n/bundle/locale.portlet.chat.Resource-${lang}.json`;
 
 // getting locale ressources
 exoi18n.loadLanguageAsync(lang, url)

--- a/application/src/main/webapp/vue-app/chatConstants.js
+++ b/application/src/main/webapp/vue-app/chatConstants.js
@@ -81,6 +81,7 @@ export const chatConstants = {
   ACTION_APPS_CLOSE: 'exo-chat-apps-close-requested',
   ACTION_ROOM_OPEN_CHAT: 'exo-chat-room-open-requested',
   ACTION_FILTER_ROOM_TYPE: 'exo-chat-room-filter-changed',
+  ACTION_CHAT_OPEN_DRAWER: 'exo-chat-open-drawer',
   EVENT_CONNECTED: 'exo-chat-connected',
   EVENT_DISCONNECTED: 'exo-chat-disconnected',
   EVENT_RECONNECTED: 'exo-chat-reconnected',

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -242,10 +242,7 @@ export default {
     chatWebSocket.unregistreEventListener();
   },
   mounted() {
-    window.addEventListener('load', () => {
-      const chatButtonElement = document.getElementById('btnChatButton');
-      chatButtonElement.addEventListener('click',this.openDrawer);
-    });
+    document.addEventListener(chatConstants.ACTION_CHAT_OPEN_DRAWER,this.openDrawer);
   },
   methods: {
     messageReceived(event) {


### PR DESCRIPTION
Prior to this change, when click the chat app button doesn't work on firefox.
To fix this, change the event load to the nextTick event.