### PR TITLE
TASK-59308: chat drawer displays blank

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -381,6 +381,8 @@ export default {
         this.externalUser = data && data.external === 'true';
       }
     );
+    this.contactList = this.contacts;
+    this.contactsToDisplay = this.this.contacts.slice();
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_ROOM_MEMBER_LEFT, this.leftRoom);


### PR DESCRIPTION
Prior to this change, when open the chat drawer after 4-5 minutes of page load it will be displayed blank .
To fix this, initialize the chat list during chat drawer creation.