### PR TITLE
 Task-58584:Actions menu in chat app is empty

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -45,6 +45,7 @@
         v-if="Object.keys(selectedContact).length !== 0"
         :is-room-notification-silence="isSelectedRoomSilence"
         :contact="selectedContact"
+        :roomActions="roomActions"
         @back-to-contact-list="conversationArea = false" />
       <div class="room-content">
         <exo-chat-message-list
@@ -110,7 +111,7 @@ import * as chatWebStorage from '../chatWebStorage';
 import * as chatWebSocket from '../chatWebSocket';
 import * as desktopNotification from '../desktopNotification';
 import {chatConstants} from '../chatConstants';
-import {installExtensions,composerApplications} from '../extension';
+import {installExtensions,composerApplications,roomActions} from '../extension';
 
 export default {
   data() {
@@ -146,6 +147,7 @@ export default {
       participantsArea: false,
       sideMenuArea: false,
       composerApplications: [],
+      roomActions: [],
     };
   },
   computed: {
@@ -173,6 +175,7 @@ export default {
         this.initSettings(userSettings);
         installExtensions(userSettings);
         this.composerApplications = composerApplications;
+        this.roomActions = roomActions;
       },
       chatRoomsData => this.initChatRooms(chatRoomsData));
 

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
@@ -123,7 +123,6 @@
 <script>
 import {chatConstants} from '../chatConstants';
 import * as chatServices from '../chatServices';
-import {roomActions} from '../extension';
 import {roomActionComponents} from '../extension';
 
 export default {
@@ -156,11 +155,17 @@ export default {
       default() {
         return false;
       }
-    }
+    },
+    roomActions: {
+      type: Array,
+      default: function () {
+        return [{}];
+      }
+    },
   },
   data() {
     return {
-      settingActions: roomActions,
+      settingActions: [],
       meetingStarted: false,
       nbMembers: 0,
       showSearchRoom: false,
@@ -207,6 +212,7 @@ export default {
     }
   },
   created() {
+    this.settingActions = this.roomActions;
     document.addEventListener(chatConstants.ACTION_ROOM_START_MEETING, this.startMeeting);
     document.addEventListener(chatConstants.ACTION_ROOM_STOP_MEETING, this.stopMeeting);
     document.addEventListener(chatConstants.ACTION_ROOM_OPEN_SETTINGS, this.openNotificationSettingsModal);


### PR DESCRIPTION
Prior to this change, when click on the three dots the menu will show empty.
To fix this, update the call of the roomActions attribute in ExoChatApp and pass as props in the exoChatRoomDetail component.