### PR TITLE
Task-58584: Left chatrooms are still displayed in favorite list

### DIFF
--- a/application/src/main/webapp/vue-app/chatConstants.js
+++ b/application/src/main/webapp/vue-app/chatConstants.js
@@ -24,6 +24,8 @@ export const chatConstants = {
   TYPE_FILTER_DEFAULT: 'All',
   STORED_PARAM_SORT_FILTER: 'exo-chat-sortFilter',
   SORT_FILTER_DEFAULT: 'Recent',
+  STORED_PARAM_TERM_FILTER: 'exo-chat-termFilter',
+  TERM_FILTER_DEFAULT: '',
   CONTACTS_PER_PAGE: 20,
   ROOMS_PER_PAGE: 20,
   ADD_TEAM_MESSAGE: 'type-add-team-user',

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -45,6 +45,7 @@
         v-if="Object.keys(selectedContact).length !== 0"
         :is-room-notification-silence="isSelectedRoomSilence"
         :contact="selectedContact"
+        :roomActions="roomActions"
         @back-to-contact-list="conversationArea = false" />
       <div class="room-content">
         <exo-chat-message-list
@@ -110,7 +111,7 @@ import * as chatWebStorage from '../chatWebStorage';
 import * as chatWebSocket from '../chatWebSocket';
 import * as desktopNotification from '../desktopNotification';
 import {chatConstants} from '../chatConstants';
-import {installExtensions,composerApplications} from '../extension';
+import {installExtensions,composerApplications,roomActions} from '../extension';
 
 export default {
   data() {
@@ -146,6 +147,7 @@ export default {
       participantsArea: false,
       sideMenuArea: false,
       composerApplications: [],
+      roomActions: [],
     };
   },
   computed: {
@@ -173,6 +175,7 @@ export default {
         this.initSettings(userSettings);
         installExtensions(userSettings);
         this.composerApplications = composerApplications;
+        this.roomActions = roomActions;
       },
       chatRoomsData => this.initChatRooms(chatRoomsData));
 

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -187,6 +187,9 @@ export default {
     document.addEventListener(chatConstants.ACTION_ROOM_OPEN_CHAT, this.openRoom);
     chatWebStorage.registreEventListener();
     chatWebSocket.registreEventListener();
+    this.$root.$on('refresh-contacts', keepSelectedContact => {
+      this.refreshContacts(keepSelectedContact);
+    });
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_DISCONNECTED, this.changeUserStatusToOffline);
@@ -348,13 +351,17 @@ export default {
       });
     },
     refreshContacts(keepSelectedContact) {
+      const typeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
+      const termFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TERM_FILTER, chatConstants.TERM_FILTER_DEFAULT);
       chatServices.getOnlineUsers().then(users => {
-        chatServices.getUserChatRooms(this.userSettings, users).then(chatRoomsData => {
+        chatServices.getUserChatRooms(this.userSettings, users, termFilter, typeFilter).then(chatRoomsData => {
           this.addRooms(chatRoomsData.rooms);
           if (!keepSelectedContact && this.selectedContact) {
             const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user);
             if (contactToChange) {
               this.setSelectedContact(contactToChange);
+            } else {
+              this.selectedContact = {};
             }
           }
         });

--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -338,13 +338,14 @@ export default {
     },
   },
   watch: {
-    contacts(newVal) {
-      this.contactList = newVal;
-      this.contactsToDisplay = this.contactList;
+    contacts() {
+      this.contactList = this.contacts.slice();
+      this.contactsToDisplay = this.contacts.slice();
     },
     searchTerm(value) {
       this.searchTerm = value;
       this.nbrePages = 0;
+      chatWebStorage.setStoredParam(chatConstants.STORED_PARAM_TERM_FILTER, this.searchTerm);
       this.$emit('change-filter-type', this.searchTerm, this.typeFilter, this.nbrePages);
     },
     searchWord(newValue) {
@@ -381,8 +382,8 @@ export default {
         this.externalUser = data && data.external === 'true';
       }
     );
-    this.contactList = this.contacts;
-    this.contactsToDisplay = this.this.contacts.slice();
+    this.contactList = this.contacts.slice();
+    this.contactsToDisplay = this.contacts.slice();
   },
   destroyed() {
     document.removeEventListener(chatConstants.EVENT_ROOM_MEMBER_LEFT, this.leftRoom);
@@ -462,7 +463,13 @@ export default {
       this.unreadMessages.shift();
     },
     toggleFavorite(contact) {
-      chatServices.toggleFavorite(contact.room, contact.user, !contact.isFavorite).then(contact.isFavorite = !contact.isFavorite);
+      chatServices.toggleFavorite(contact.room, contact.user, !contact.isFavorite).then(
+        () => {
+          contact.isFavorite = !contact.isFavorite;
+          this.$emit('refresh-contacts', true);
+          this.sortFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_SORT_FILTER, chatConstants.SORT_FILTER_DEFAULT);
+        }
+      );
     },
     selectSortFilter(filter) {
       this.sortFilter = filter;
@@ -473,6 +480,7 @@ export default {
       chatWebStorage.setStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, this.typeFilter);
       this.nbrePages = 0;
       this.$emit('change-filter-type', this.searchTerm, this.typeFilter, this.nbrePages);
+      this.$emit('refresh-contacts', true);
     },
     initFilterMobile() {
       this.typeFilterMobile = this.typeFilter;

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
@@ -123,7 +123,6 @@
 <script>
 import {chatConstants} from '../chatConstants';
 import * as chatServices from '../chatServices';
-import {roomActions} from '../extension';
 import {roomActionComponents} from '../extension';
 
 export default {
@@ -156,11 +155,17 @@ export default {
       default() {
         return false;
       }
-    }
+    },
+    roomActions: {
+      type: Array,
+      default: function () {
+        return [{}];
+      }
+    },
   },
   data() {
     return {
-      settingActions: roomActions,
+      settingActions: [],
       meetingStarted: false,
       nbMembers: 0,
       showSearchRoom: false,
@@ -207,6 +212,7 @@ export default {
     }
   },
   created() {
+    this.settingActions = this.roomActions;
     document.addEventListener(chatConstants.ACTION_ROOM_START_MEETING, this.startMeeting);
     document.addEventListener(chatConstants.ACTION_ROOM_STOP_MEETING, this.stopMeeting);
     document.addEventListener(chatConstants.ACTION_ROOM_OPEN_SETTINGS, this.openNotificationSettingsModal);

--- a/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatRoomDetail.vue
@@ -108,7 +108,7 @@
             id="team-delete-button-ok"
             href="#"
             class="btn btn-primary"
-            @click="confirmAction(contact);showConfirmModal=false;">{{ $t(confirmOKMessage) }}</a>
+            @click="confirmAction(contact);leaveRoomAndRemoveFavorite(contact);">{{ $t(confirmOKMessage) }}</a>
           <a
             id="team-delete-button-cancel"
             href="#"
@@ -172,7 +172,8 @@ export default {
       confirmOKMessage: '',
       confirmKOMessage: '',
       confirmAction(){return;},
-      roomActionComponents: roomActionComponents
+      roomActionComponents: roomActionComponents,
+      settingKey: '',
     };
   },
   computed: {
@@ -228,14 +229,26 @@ export default {
   methods: {
     addToFavorite(e) {
       const contact = e.detail;
-      chatServices.toggleFavorite(contact.room, contact.user, true).then(contact.isFavorite = true);
+      chatServices.toggleFavorite(contact.room, contact.user, true).then(() => 
+      {
+        contact.isFavorite = true;
+        this.$root.$emit('refresh-contacts', true);
+      });
     },
     removeFromFavorite(e) {
       const contact = e.detail;
-      chatServices.toggleFavorite(contact.room, contact.user, false).then(contact.isFavorite = false);
+      chatServices.toggleFavorite(contact.room, contact.user, false).then(() => 
+      {
+        contact.isFavorite = false;
+        this.$root.$emit('refresh-contacts', true);
+      });
     },
     toggleFavorite(contact) {
-      chatServices.toggleFavorite(contact.room, contact.user, !contact.isFavorite).then(contact.isFavorite = !contact.isFavorite);
+      chatServices.toggleFavorite(contact.room, contact.user, !contact.isFavorite).then(() =>
+      {
+        contact.isFavorite = !contact.isFavorite;
+        this.$root.$emit('refresh-contacts', true);
+      });
     },
     openSearchRoom() {
       this.showSearchRoom = true;
@@ -262,10 +275,22 @@ export default {
         this.confirmKOMessage = settingAction.confirm.koMessage;
         this.confirmAction = settingAction.confirm.confirmed;
         this.showConfirmModal = true;
+        this.settingKey = settingAction.key;
       } else {
         document.dispatchEvent(new CustomEvent(`exo-chat-setting-${settingAction.key}-requested`, {'detail': this.contact}));
       }
-      this.$children[1].$el.classList.remove('open');
+      if (this.$children[1] && this.$children[1].$el && this.$children[1].$el.classList) {
+        this.$children[1].$el.classList.remove('open');
+      }
+    },
+    leaveRoomAndRemoveFavorite(contact) {
+      if (this.settingKey === 'leaveRoom') {
+        if (contact && contact.isFavorite) {
+          chatServices.toggleFavorite(contact.room, contact.user, false).then(contact.isFavorite = false);
+        }
+        this.$root.$emit('refresh-contacts', false);
+      }
+      this.showConfirmModal=false;
     },
     checkMeetingStatus() {
       chatServices.getRoomDetail(eXo.chat.userSettings, this.contact.room).then(contact => {

--- a/application/src/main/webapp/vue-app/extension.js
+++ b/application/src/main/webapp/vue-app/extension.js
@@ -491,7 +491,7 @@ registerDefaultExtensions('room-action', DEFAULT_ROOM_ACTIONS);
 
 export const extraMessageTypes = getExtensionsByType('message-type');
 export const extraMessageNotifs = getExtensionsByType('message-notif');
-export const roomActions = getExtensionsByType('room-action');
+export let roomActions = getExtensionsByType('room-action');
 export const roomActionComponents = getExtensionsByType('room-action-component');
 export const miniChatTitleActionComponents = getExtensionsByType('mini-chat-title-action-component');
 export let composerApplications = getExtensionsByType('composer-application');
@@ -514,4 +514,5 @@ export function installExtensions(settings) {
 
   composerApplications = getExtensionsByType('composer-application');
   messageActions = getExtensionsByType('message-action');
+  roomActions = getExtensionsByType('room-action');
 }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/ChatMongoDataStorage.java
@@ -999,6 +999,7 @@ public class ChatMongoDataStorage implements ChatDataStorage {
         roomBean.setAvailableUser(true);
         roomBean.setFullName(room.get("team").toString());
         roomBean.setType(TYPE_ROOM_TEAM);
+        roomBean.setFavorite(userBean.isFavorite(roomId));
         if (StringUtils.isNotBlank(roomBean.getUser())) {
           roomBean.setAdmins(new String[]{room.get("user").toString()});
         }


### PR DESCRIPTION
Prior to this change, when click on the three dots the menu will show empty.
To fix this, update the call of the `roomActions` attribute in `ExoChatApp` and pass as props in the `exoChatRoomDetail` component.