### PR TITLE
fix:add ids for mini chat drawer icons - EXO-61071 (#564)

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -101,6 +101,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </v-icon>
           <v-icon
             v-show="!showSearch && !selectedContact"
+            id="chatFilter"
             class="my-auto"
             @click="openContactSearch">
             mdi-filter
@@ -108,6 +109,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <v-icon
             v-show="mq !=='mobile' && !showSearch"
             :title="$t('exoplatform.chat.open.chat')"
+            id="openChat"
             class="my-auto"
             @click="navigateTo">
             mdi-open-in-new


### PR DESCRIPTION
before this fix mini chat drawer icons doesn't have ids
 this fix add ids is useful for automatic tests