### PR TITLE
fix: set correct value for websocket message size limitation - EXO-59044

### DIFF
--- a/application/src/main/webapp/vue-app/chatWebSocket.js
+++ b/application/src/main/webapp/vue-app/chatWebSocket.js
@@ -25,7 +25,8 @@ export function initSettings(settings) {
       const wsConfig = {
         url: cometDSettings.wsEndpoint,
         'exoId': cometDSettings.username,
-        'exoToken': cometDSettings.cometdToken
+        'exoToken': cometDSettings.cometdToken,
+        maxSendBayeuxMessageSize: 10485760
       };
       cometDSettings.cCometD.configure(wsConfig);
     }
@@ -140,6 +141,8 @@ export function leaveRoom(room, callback) {
   cometDSettings.cCometD.publish('/service/chat', content, function(publishAck) {
     if (publishAck && publishAck.successful && callback) {
       callback();
+    } else if (publishAck.failure) {
+      console.error(`Error when sending message on ${publishAck.failure.connectionType} with exception : ${publishAck.failure.exception}`);
     }
   });
 }
@@ -156,6 +159,8 @@ export function deleteRoom(room, callback) {
   cometDSettings.cCometD.publish('/service/chat', content, function(publishAck) {
     if (publishAck && publishAck.successful && callback) {
       callback();
+    } else if (publishAck.failure) {
+      console.error(`Error when sending message on ${publishAck.failure.connectionType} with exception : ${publishAck.failure.exception}`);
     }
   });
 }
@@ -189,6 +194,7 @@ export function sendMessage(messageObj, callback) {
   try {
     cometDSettings.cCometD.publish('/service/chat', JSON.stringify(content), function(publishAck) {
       if (!publishAck || !publishAck.successful) {
+        console.error(`Error when sending message on ${publishAck.failure.connectionType} with exception : ${publishAck.failure.exception}`);
         document.dispatchEvent(new CustomEvent(chatConstants.EVENT_MESSAGE_NOT_SENT, {'detail': data}));
       } else {
         document.dispatchEvent(new CustomEvent(chatConstants.EVENT_MESSAGE_SENT, {detail: content}));
@@ -219,6 +225,8 @@ export function deleteMessage(messageObj, callback) {
       if (typeof callback === 'function') {
         callback();
       }
+    } else if (publishAck.failure) {
+      console.error(`Error when sending message on ${publishAck.failure.connectionType} with exception : ${publishAck.failure.exception}`);
     }
   });
 }
@@ -236,6 +244,8 @@ export function setRoomMessagesAsRead(room, callback) {
         if (typeof callback === 'function') {
           callback();
         }
+      } else if (publishAck.failure) {
+        console.error(`Error when sending message on ${publishAck.failure.connectionType} with exception : ${publishAck.failure.exception}`);
       }
     });
   }
@@ -251,7 +261,8 @@ function renewToken() {
       const wsConfig = {
         url: cometDSettings.wsEndpoint,
         'exoId': cometDSettings.username,
-        'exoToken': cometDSettings.cometdToken
+        'exoToken': cometDSettings.cometdToken,
+        maxSendBayeuxMessageSize: 10485760
       };
       cometDSettings.cCometD.configure(wsConfig);
       initChatCometd();

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -45,7 +45,7 @@
         v-if="Object.keys(selectedContact).length !== 0"
         :is-room-notification-silence="isSelectedRoomSilence"
         :contact="selectedContact"
-        :roomActions="roomActions"
+        :room-actions="roomActions"
         @back-to-contact-list="conversationArea = false" />
       <div class="room-content">
         <exo-chat-message-list

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -389,7 +389,7 @@ export default {
         const pastedImage = item.getAsFile();
         const reader = new FileReader();
         reader.onload = function (event) {
-          this.$refs.messageComposerArea.src = event.target.result;
+          $('#messageComposerArea').src = event.target.result;
         };
         reader.readAsDataURL(pastedImage);
       } else {


### PR DESCRIPTION
After upgradinf Cometd to 6.0.7, the functionality of copy/paste images in chat composer does no more work The issue was caused by a new parameter maxSendBayeuxMessageSize introduced to limit the websocket message size on client side. This fix sets the value of the parameter maxSendBayeuxMessageSize to be equal to the one present in cometd servlet initialization parameters Some console.error instructions were added to help detect cometd communication failures and print their causes.
