### PR TITLE
fix: chat server standalone deployment and update dependencies - EXO-62670

### DIFF
--- a/packaging/standalone-server-tomcat-distrib/pom.xml
+++ b/packaging/standalone-server-tomcat-distrib/pom.xml
@@ -32,6 +32,19 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>${org.slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>commons-compiler</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <org.apache.tomcat.version>9.0.60</org.apache.tomcat.version>
     <quartz.version>2.2.2</quartz.version>
     <org.slf4j.version>1.7.36</org.slf4j.version>
-    <ch.qas.logback.version>1.2.6</ch.qas.logback.version>
+    <ch.qas.logback.version>1.2.7</ch.qas.logback.version>
     <org.codehaus.janino.version>2.6.1</org.codehaus.janino.version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,15 +43,18 @@
     <de.flapdoodle.embed.mongo.version>2.0.3</de.flapdoodle.embed.mongo.version>
     <commons-compress.version>1.5</commons-compress.version>
     <javax.enterprise.cdi.version>1.0-SP4</javax.enterprise.cdi.version>
-    <mongodb-java-driver.version>3.5.0</mongodb-java-driver.version>
+    <mongodb-java-driver.version>3.12.12</mongodb-java-driver.version>
     <com.google.inject.guice.version>3.0</com.google.inject.guice.version>
     <aopalliance.version>1.0</aopalliance.version>
     <com.google.json-simple.version>1.1.1</com.google.json-simple.version>
 
     <!-- The apache tomcat version to bundle -->
-    <org.apache.tomcat.version>8.5.65</org.apache.tomcat.version>
+    <org.apache.tomcat.version>9.0.60</org.apache.tomcat.version>
     <quartz.version>2.2.2</quartz.version>
-    <org.slf4j.version>1.7.7</org.slf4j.version>
+    <org.slf4j.version>1.7.36</org.slf4j.version>
+    <ch.qas.logback.version>1.2.6</ch.qas.logback.version>
+    <org.codehaus.janino.version>2.6.1</org.codehaus.janino.version>
+
 
     <!-- **************************************** -->
     <!-- Jenkins Settings -->
@@ -251,8 +254,35 @@
         <artifactId>slf4j-api</artifactId>
         <version>${org.slf4j.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${org.slf4j.version}</version>
+      </dependency>
+      <!--logback-->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${ch.qas.logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${ch.qas.logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.janino</groupId>
+        <artifactId>janino</artifactId>
+        <version>${org.codehaus.janino.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.janino</groupId>
+        <artifactId>commons-compiler</artifactId>
+        <version>${org.codehaus.janino.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
   
   <!-- This profile is used to allow github action to build branches. The github action is used for sonar analysis -->
   <profiles>


### PR DESCRIPTION
Before this PR, the chat application server standalone stucks on startup due to missing ch.qos.logback and org.codehaus.janino dependencies' versions resolution. Besides, the used tomcat version was 8.5.56 and the mongo driver's was 3.5.0.
This PR introduce missing dependencies and upgrade tomcat and mongo driver's