### PR TITLE
 fix: [Chat]Chat Notifications is duplicated - EXO-53349 (#596)

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -317,9 +317,11 @@ export default {
     },
     openDrawer() {
       this.$refs.chatDrawer.startLoading();
+      this.contactList = [];
       chatServices.initChatSettings(this.userSettings.username, false,
         userSettings => this.initSettings(userSettings),
         chatRoomsData => {
+          this.contactList = chatRoomsData.rooms.slice();
           this.initChatRooms(chatRoomsData);
           this.$nextTick(this.$refs.chatDrawer.endLoading);
         },
@@ -417,7 +419,6 @@ export default {
     },
     initChatRooms(chatRoomsData) {
       this.loadingContacts = false;
-      this.addRooms(chatRoomsData.rooms);
       const totalUnreadMsg = Math.abs(chatRoomsData.unreadOffline)
                            + Math.abs(chatRoomsData.unreadOnline)
                            + Math.abs(chatRoomsData.unreadSpaces)


### PR DESCRIPTION
Prior to this change, cat notification is duplicated in cat drawer. After this changes, the contact list is displayed properly in Chat Drawer.