### PR TITLE
fix: Enable to open a file containing an '+' character in its title in the chat application - EXO-64326 (#612)

### DIFF
--- a/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
+++ b/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
@@ -2,6 +2,7 @@ package org.exoplatform.chat.service;
 
 import java.io.*;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -16,6 +17,7 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang.StringUtils;
 
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.gatein.common.text.EntityEncoder;
 import org.json.JSONArray;
@@ -188,6 +190,9 @@ public class DocumentService implements ResourceContainer {
     String workspace = node.getSession().getWorkspace().getName();
     String repository = ((ManageableRepository) node.getSession().getRepository()).getConfiguration().getName();
     String nodePathWithWorkspace = workspace + node.getPath();
+    String nodeName = node.getName();
+    String encodedNodeName = URLEncoder.encode(nodeName, "UTF-8").replace("%", "%25");
+    nodePathWithWorkspace = nodePathWithWorkspace.replace(nodeName, encodedNodeName);
     String baseDavPath = "/jcr/" + repository + "/" + nodePathWithWorkspace;
     String publicURL = RestUtils.getBaseRestUrl() + baseDavPath;
     String thumbnailURL = "/" + PortalContainer.getCurrentPortalContainerName() + "/" + CommonsUtils.getRestContextName() + "/thumbnailImage/large/" + repository + "/"
@@ -228,7 +233,7 @@ public class DocumentService implements ResourceContainer {
                          List<String> usernames) {
     String filename = getFileName(uploadResource);
     String title = filename;
-    filename = Text.escapeIllegalJcrChars(filename);
+    filename = Text.escapeIllegalJcrChars(Utils.cleanName(filename));
 
     boolean isPrivateContext = !room.startsWith(ChatService.SPACE_PREFIX);
 


### PR DESCRIPTION

Before to this change , after uploading a file with name containing a '+' character in chat application ,we were unable to open it , the problem that was the '+' character on the file's path being replaced by a space . After encoding the node name , This change is going to clean the file name using the utils clean name method.