### PR TITLE
fix : Enable to preview and download file with name contains a special character - EXO-64575 (#614)

### DIFF
--- a/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
+++ b/services/src/main/java/org/exoplatform/chat/service/DocumentService.java
@@ -233,7 +233,7 @@ public class DocumentService implements ResourceContainer {
                          List<String> usernames) {
     String filename = getFileName(uploadResource);
     String title = filename;
-    filename = Text.escapeIllegalJcrChars(Utils.cleanName(filename));
+    filename = Text.escapeIllegalJcrChars(Utils.cleanName(Utils.cleanNameWithAccents(filename)));
 
     boolean isPrivateContext = !room.startsWith(ChatService.SPACE_PREFIX);
 


### PR DESCRIPTION

This change will clean the uploaded file name by removing accents in the chat application