### PR TITLE
Update OS & MongoDB embedded version for Unit tests - EXO-64714

### DIFF
--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -156,7 +156,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_22_10 -Dchat.embeddedMongoDBVersion=6.0</argLine>
+          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_20_04 -Dchat.embeddedMongoDBVersion=6.0.6</argLine>
         </configuration>
       </plugin>
 

--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -156,7 +156,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_20_04 -Dchat.embeddedMongoDBVersion=6.0.6</argLine>
+          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_20_04 -Dchat.embeddedMongoDBVersion=6.0</argLine>
         </configuration>
       </plugin>
 

--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -156,7 +156,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_16_04 -Dchat.embeddedMongoDBVersion=4.2</argLine>
+          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_22_10 -Dchat.embeddedMongoDBVersion=6.0</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Following the update of the Ubuntu version on all Jenkins job, we will need to upgrade the embedded MongoDB & OS versions to use Ubuntu 22.10 and MongoDB 6.0