### PR TITLE
fix: swallowed exception when updating the preferences of notifications - EXO-64706

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -695,6 +695,7 @@ public class ChatServer
         try {
           userService.setPreferredNotification(user, notifCondition);
         } catch (Exception e) {
+          LOG.severe("Error while updating the preferences of the user notifications: " + e.getMessage());
         }
       }
     }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -138,7 +138,7 @@ public class UserMongoDataStorage implements UserDataStorage {
     if (cursor.hasNext()) {
       Document doc = cursor.next();
       if(ChatService.BIP.equals(notifManner) || ChatService.DESKTOP_NOTIFICATION.equals(notifManner) || ChatService.ON_SITE.equals(notifManner)) {
-        BasicDBObject settings = (BasicDBObject) doc.get(NOTIFICATIONS_SETTINGS);
+        Document settings = (Document) doc.get(NOTIFICATIONS_SETTINGS);
         Object prefNotif = null;
         Object prefTriger = null;
         Object existingRoomNotif =null;
@@ -147,7 +147,7 @@ public class UserMongoDataStorage implements UserDataStorage {
           prefTriger = settings.get(PREFERRED_NOTIFICATION_TRIGGER);
           existingRoomNotif = settings.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER);
         } else {
-          settings = new BasicDBObject();
+          settings = new Document();
         }
         List<String> existingPrefNotif = null;
         if(prefNotif==null) {


### PR DESCRIPTION
When an exception occurs while saving user preferences for Chat notifications, the error is swallowed and no trace is there.
the fix will fill the catch blocks and fixes the cast error of BasicDBObject to a Bson Document.