### PR TITLE
fix: error when retrieving chat settings - EXO-64706

### DIFF
--- a/application/src/main/webapp/vue-app/chatServices.js
+++ b/application/src/main/webapp/vue-app/chatServices.js
@@ -354,20 +354,32 @@ export function getUserNotificationSettings(userSettings) {
 }
 
 export function loadNotificationSettings(settings) {
-  if (settings && settings.userDesktopNotificationSettings) {
+  if (settings?.userDesktopNotificationSettings) {
     eXo.chat.desktopNotificationSettings = settings.userDesktopNotificationSettings;
     if (eXo.chat.desktopNotificationSettings.preferredNotification) {
-      eXo.chat.desktopNotificationSettings.preferredNotification = JSON.parse(eXo.chat.desktopNotificationSettings.preferredNotification);
+      try {
+        eXo.chat.desktopNotificationSettings.preferredNotification = JSON.parse(eXo.chat.desktopNotificationSettings.preferredNotification);
+      } catch (ignoredException) {
+        // we do nothing
+      }
     } else {
       eXo.chat.desktopNotificationSettings.preferredNotification = [];
     }
     if (eXo.chat.desktopNotificationSettings.preferredNotificationTrigger) {
-      eXo.chat.desktopNotificationSettings.preferredNotificationTrigger = JSON.parse(eXo.chat.desktopNotificationSettings.preferredNotificationTrigger);
+      try {
+        eXo.chat.desktopNotificationSettings.preferredNotificationTrigger = JSON.parse(eXo.chat.desktopNotificationSettings.preferredNotificationTrigger);
+      } catch (IgnoredException) {
+        // Nothing to do , settings is already parsed
+      }
     } else {
       eXo.chat.desktopNotificationSettings.preferredNotificationTrigger = [];
     }
     if (eXo.chat.desktopNotificationSettings.preferredRoomNotificationTrigger) {
-      eXo.chat.desktopNotificationSettings.preferredRoomNotificationTrigger = JSON.parse(eXo.chat.desktopNotificationSettings.preferredRoomNotificationTrigger);
+      try {
+        eXo.chat.desktopNotificationSettings.preferredRoomNotificationTrigger = JSON.parse(eXo.chat.desktopNotificationSettings.preferredRoomNotificationTrigger);
+      } catch (IgnoredException) {
+        // Nothing to do , settings is already parsed
+      }
     } else {
       eXo.chat.desktopNotificationSettings.preferredRoomNotificationTrigger = [];
     }

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,8 @@
 
     <!-- TODO check dependencies from parent pom -->
     <commons-lang3.version>3.2</commons-lang3.version>
-    <commons-codec.version>1.4</commons-codec.version>
     <de.flapdoodle.embed.mongo.version>4.6.3</de.flapdoodle.embed.mongo.version>
-    <commons-compress.version>1.5</commons-compress.version>
+    <commons-compress.version>1.22</commons-compress.version>
     <javax.enterprise.cdi.version>1.0-SP4</javax.enterprise.cdi.version>
     <mongodb-java-driver.version>4.9.1</mongodb-java-driver.version>
     <com.google.inject.guice.version>3.0</com.google.inject.guice.version>
@@ -76,11 +75,6 @@
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
         <version>${com.google.json-simple.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>de.flapdoodle.embed</groupId>

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -695,6 +695,7 @@ public class ChatServer
         try {
           userService.setPreferredNotification(user, notifCondition);
         } catch (Exception e) {
+          LOG.severe("Error while updating the preferences of the user notifications: " + e.getMessage());
         }
       }
     }

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -310,17 +310,19 @@ public class UserMongoDataStorage implements UserDataStorage {
         wrapperDoc = new Document();
       }
 
-      if(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION)!=null){
+      if(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION) != null){
         settings.setEnabledChannels(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION).toString());
       } else {
         //default values to the untouched settings
         settings.setEnabledChannels(DEFAULT_ENABLED_CHANNELS);
       }
-      if(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER)!=null){
-        settings.setEnabledTriggers(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER).toString());
+      if(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER) != null){
+        Document preferredNotificationsTrigger = (Document)(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER));
+        settings.setEnabledTriggers(preferredNotificationsTrigger.toJson());
       }
       if(wrapperDoc.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER) != null) {
-        settings.setEnabledRoomTriggers(wrapperDoc.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER).toString());
+        Document preferredRoomNotificationTrigger = (Document) wrapperDoc.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER);
+        settings.setEnabledRoomTriggers(preferredRoomNotificationTrigger.toJson());
       }
     }
     return settings;

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -138,7 +138,7 @@ public class UserMongoDataStorage implements UserDataStorage {
     if (cursor.hasNext()) {
       Document doc = cursor.next();
       if(ChatService.BIP.equals(notifManner) || ChatService.DESKTOP_NOTIFICATION.equals(notifManner) || ChatService.ON_SITE.equals(notifManner)) {
-        BasicDBObject settings = (BasicDBObject) doc.get(NOTIFICATIONS_SETTINGS);
+        Document settings = (Document) doc.get(NOTIFICATIONS_SETTINGS);
         Object prefNotif = null;
         Object prefTriger = null;
         Object existingRoomNotif =null;
@@ -147,7 +147,7 @@ public class UserMongoDataStorage implements UserDataStorage {
           prefTriger = settings.get(PREFERRED_NOTIFICATION_TRIGGER);
           existingRoomNotif = settings.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER);
         } else {
-          settings = new BasicDBObject();
+          settings = new Document();
         }
         List<String> existingPrefNotif = null;
         if(prefNotif==null) {

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -317,8 +317,7 @@ public class UserMongoDataStorage implements UserDataStorage {
         settings.setEnabledChannels(DEFAULT_ENABLED_CHANNELS);
       }
       if(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER) != null){
-        Document preferredNotificationsTrigger = (Document)(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER));
-        settings.setEnabledTriggers(preferredNotificationsTrigger.toJson());
+        settings.setEnabledTriggers(wrapperDoc.get(UserDataStorage.PREFERRED_NOTIFICATION_TRIGGER).toString());
       }
       if(wrapperDoc.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER) != null) {
         Document preferredRoomNotificationTrigger = (Document) wrapperDoc.get(PREFERRED_ROOM_NOTIFICATION_TRIGGER);


### PR DESCRIPTION
After upgrading the MongoDB version, teh toString function of a document does not return the JSON representation, thus it fails to be parsed to a JSON object. This caused errors when retrieving the chat settings of notifications for users.
The fix will convert the embedded object to a Document and retrieve the JSON representation.