### PR TITLE
fix : Remove the limit when getting the list of room participants in edit mode - EXO-64727 

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatContactList.vue
@@ -625,7 +625,7 @@ export default {
       this.selectContact(room);
     },
     editRoom() {
-      chatServices.getRoomParticipants(eXo.chat.userSettings, this.selected).then(data => {
+      chatServices.getRoomParticipants(eXo.chat.userSettings, this.selected, null, 0).then(data => {
         // eslint-disable-next-line vue/no-mutating-props
         this.selected.participants = data.users;
         this.newRoom = JSON.parse(JSON.stringify(this.selected));


### PR DESCRIPTION
Before this change, when we created a room with more than 20 participants and attempted to edit it, the number of participants would decrease to 20. This issue was caused by the default limit being used when retrieving the room participants This change will set the limit to zero .