### PR TITLE
fix: stop retrieving online users when some requests are pending - EXO-65044

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -370,8 +370,9 @@ export default {
                 this.selectedContact = {};
               }
             }
-            this.unresolvedRequests--;
           });
+        }).finally(() => {
+          this.unresolvedRequests--;
         });
       }
     },

--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -148,6 +148,7 @@ export default {
       sideMenuArea: false,
       composerApplications: [],
       roomActions: [],
+      unresolvedRequests: 0,
     };
   },
   computed: {
@@ -354,21 +355,25 @@ export default {
       });
     },
     refreshContacts(keepSelectedContact) {
-      const typeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
-      const termFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TERM_FILTER, chatConstants.TERM_FILTER_DEFAULT);
-      chatServices.getOnlineUsers().then(users => {
-        chatServices.getUserChatRooms(this.userSettings, users, termFilter, typeFilter).then(chatRoomsData => {
-          this.addRooms(chatRoomsData.rooms);
-          if (!keepSelectedContact && this.selectedContact) {
-            const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user);
-            if (contactToChange) {
-              this.setSelectedContact(contactToChange);
-            } else {
-              this.selectedContact = {};
+      if (this.unresolvedRequests < 3) {
+        this.unresolvedRequests++;
+        const typeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
+        const termFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TERM_FILTER, chatConstants.TERM_FILTER_DEFAULT);
+        chatServices.getOnlineUsers().then(users => {
+          chatServices.getUserChatRooms(this.userSettings, users, termFilter, typeFilter).then(chatRoomsData => {
+            this.addRooms(chatRoomsData.rooms);
+            if (!keepSelectedContact && this.selectedContact) {
+              const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user);
+              if (contactToChange) {
+                this.setSelectedContact(contactToChange);
+              } else {
+                this.selectedContact = {};
+              }
             }
-          }
+            this.unresolvedRequests--;
+          });
         });
-      });
+      }
     },
     changeUserStatusToOffline() {
       if (this.userSettings && this.userSettings.status && !this.userSettings.originalStatus) {

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -415,7 +415,7 @@ export default {
       if (this.userSettings.offlineDelay) {
         setInterval(
           function() {thiss.refreshContacts(true);},
-          500);
+          this.userSettings.offlineDelay);
       }
     },
     initChatRooms(chatRoomsData) {

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -481,8 +481,9 @@ export default {
                 this.setSelectedContact(contactToChange);
               }
             }
-            this.unresolvedRequests--;
           });
+        }).finally(() => {
+          this.unresolvedRequests--;
         });
       }
     },


### PR DESCRIPTION
When client OS goes suspended or there is issue connecting to eXo platform server, the requests retriving online users do not stop and are queued on the browser. Once the connection is re-established, all those requests are processed at once causing an unnecessary workload on the server, and sometimes they causing server AND client browser hanging.
The fix limits the number of unfinished requests to 3 to make sure it waits before resending new request 