### PR TITLE
fix: exisiting users in a chatroom are suggested to be added again in edit mode - EXO-64919

### DIFF
--- a/application/src/main/webapp/vue-app/components/modal/ExoChatRoomFormModal.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatRoomFormModal.vue
@@ -19,6 +19,7 @@
           v-model="participants"
           :search-options="{}"
           :key="participants"
+          :ignore-items="listIgnoreItems"
           name="invitePeople"
           multiple
           include-users />
@@ -70,6 +71,7 @@ export default {
   data() {
     return {
       participants: [],
+      listIgnoreItems: [],
       fullName: '',
       showErrorModal: false,
       errorModalTitle: '',
@@ -89,6 +91,13 @@ export default {
     }
   },
   watch: {
+    participants(newVal) {
+      this.listIgnoreItems = newVal.forEach(participant => {
+        if (participant.id.indexOf('organization:')<0) {
+          participant.id = 'organization:'.concat(participant.id);
+        }
+      });
+    },
     show(newValue) {
       if (this.selected && newValue) {
         this.fullName = this.selected.fullName;


### PR DESCRIPTION
Prior to this change, when edit the chatroom and try to add user again. To fix this problem, modify the participant id to be compatible with the suggested user id. After this change, existing members shouldn't be suggested as members to be added on edit mode.