### PR TITLE
fix: stop retrieving online users when some requests are pending - EXO-65044

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatApp.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatApp.vue
@@ -148,6 +148,7 @@ export default {
       sideMenuArea: false,
       composerApplications: [],
       roomActions: [],
+      unresolvedRequests: 0,
     };
   },
   computed: {
@@ -354,21 +355,26 @@ export default {
       });
     },
     refreshContacts(keepSelectedContact) {
-      const typeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
-      const termFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TERM_FILTER, chatConstants.TERM_FILTER_DEFAULT);
-      chatServices.getOnlineUsers().then(users => {
-        chatServices.getUserChatRooms(this.userSettings, users, termFilter, typeFilter).then(chatRoomsData => {
-          this.addRooms(chatRoomsData.rooms);
-          if (!keepSelectedContact && this.selectedContact) {
-            const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user);
-            if (contactToChange) {
-              this.setSelectedContact(contactToChange);
-            } else {
-              this.selectedContact = {};
+      if (this.unresolvedRequests < 3) {
+        this.unresolvedRequests++;
+        const typeFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TYPE_FILTER, chatConstants.TYPE_FILTER_DEFAULT);
+        const termFilter = chatWebStorage.getStoredParam(chatConstants.STORED_PARAM_TERM_FILTER, chatConstants.TERM_FILTER_DEFAULT);
+        chatServices.getOnlineUsers().then(users => {
+          chatServices.getUserChatRooms(this.userSettings, users, termFilter, typeFilter).then(chatRoomsData => {
+            this.addRooms(chatRoomsData.rooms);
+            if (!keepSelectedContact && this.selectedContact) {
+              const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user);
+              if (contactToChange) {
+                this.setSelectedContact(contactToChange);
+              } else {
+                this.selectedContact = {};
+              }
             }
-          }
+          });
+        }).finally(() => {
+          this.unresolvedRequests--;
         });
-      });
+      }
     },
     changeUserStatusToOffline() {
       if (this.userSettings && this.userSettings.status && !this.userSettings.originalStatus) {

--- a/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
+++ b/application/src/main/webapp/vue-app/components/modal/ExoChatDrawer.vue
@@ -181,7 +181,8 @@ export default {
       external: this.$t('exoplatform.chat.external'),
       chatLink: `/portal/${eXo.env.portal.portalName}/chat`,
       titleActionComponents: miniChatTitleActionComponents,
-      isExternal: false
+      isExternal: false,
+      unresolvedRequests: 0
     };
   },
   computed: {
@@ -469,17 +470,22 @@ export default {
       this.showSearch = false;
     },
     refreshContacts(keepSelectedContact) {
-      chatServices.getOnlineUsers().then(users => {
-        chatServices.getUserChatRooms(this.userSettings, users).then(chatRoomsData => {
-          this.addRooms(chatRoomsData.rooms);
-          if (!keepSelectedContact && this.selectedContact) {
-            const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user || contact.room === this.selectedContact);
-            if (contactToChange) {
-              this.setSelectedContact(contactToChange);
+      if (this.unresolvedRequests < 3) {
+        this.unresolvedRequests++;
+        chatServices.getOnlineUsers().then(users => {
+          chatServices.getUserChatRooms(this.userSettings, users).then(chatRoomsData => {
+            this.addRooms(chatRoomsData.rooms);
+            if (!keepSelectedContact && this.selectedContact) {
+              const contactToChange = this.contactList.find(contact => contact.room === this.selectedContact.room || contact.user === this.selectedContact.user || contact.room === this.selectedContact);
+              if (contactToChange) {
+                this.setSelectedContact(contactToChange);
+              }
             }
-          }
+          });
+        }).finally(() => {
+          this.unresolvedRequests--;
         });
-      });
+      }
     },
     searchContacts(term) {
       this.loadingContacts = true;


### PR DESCRIPTION
When client OS goes suspended or there is issue connecting to eXo platform server, the requests retreiving online users do not stop and are queued on the browser. Once the connection is re-established, all those requests are processed at once causing an unnecessary workload on the server, and sometimes they causing server AND client browser hanging. The fix limits the number of unfinished requests to 3 to make sure it waits before resending new request

(cherry picked from commit 8de21a2620b54d97178e8c04dabdc428af911734)