### PR TITLE
fix: Chat icon should only be displayed for space members - EXO-64806

### DIFF
--- a/application/src/main/webapp/vue-app/components/PopoverChatButton.vue
+++ b/application/src/main/webapp/vue-app/components/PopoverChatButton.vue
@@ -34,19 +34,21 @@ export default {
   },
   data() {
     return {
-      spaceChatEnabled: true,
+      spaceChatEnabled: false,
     };
   },
   created() {
     if ( this.identityType === 'space' ) {
-      chatServices.getUserSettings()
-        .then(userSettings => {
-          this.userSettings = userSettings;
-          chatServices.isRoomEnabled(this.userSettings, this.identityId)
-            .then(value => {
+      chatServices.getUserSettings().then(userSettings => {
+        this.userSettings = userSettings;
+        this.$spaceService.isSpaceMember(this.identityId, this.userSettings.username).then(data => {
+          if (data.isMember === 'true') {
+            chatServices.isRoomEnabled(this.userSettings, this.identityId).then(value => {
               this.spaceChatEnabled = value === 'true';
             });
+          }
         });
+      });
     }
   },
   methods: {


### PR DESCRIPTION
Prior to this change, when create article in spaceX and publish it on target, create program whose audience spaceX, share activity from spaceX to spaceY and create user1 simple user & user2 admin on plf/ spaces manager not members in spaceX open this article from target and hover on spaceX link, chat icon is visible for none members and opens the drawer. To fix this problem, added to the check if this room enebled another check if this user current is a member of this space in the popverChatButton and to ensure that the chat button only appears for members of this space add one another check during their display in the popver if this user is a member in this space. After this change,chat icon is displayed for spaceX members only.

(cherry picked from commit 47099394a95543d4097151006f348ffd4f2c6603)