### PR TITLE
fix: chat icon on users popover not displayed - EXO-65999

### DIFF
--- a/application/src/main/webapp/vue-app/components/PopoverChatButton.vue
+++ b/application/src/main/webapp/vue-app/components/PopoverChatButton.vue
@@ -34,11 +34,12 @@ export default {
   },
   data() {
     return {
-      spaceChatEnabled: false,
+      spaceChatEnabled: true,
     };
   },
   created() {
     if ( this.identityType === 'space' ) {
+      this.spaceChatEnabled = false;
       chatServices.getUserSettings().then(userSettings => {
         this.userSettings = userSettings;
         this.$spaceService.isSpaceMember(this.identityId, this.userSettings.username).then(data => {


### PR DESCRIPTION
Prior to this change, when  hover on another user popover, chat icon for that user popover not displayed .After this change, chat icon for that user popover is displayed.

(cherry picked from commit 1fc35c206a4c8f38de987bcf14ce8d1e3a7552d7)