### PR TITLE
fix : Emojis aren't recognized after the break line in the chat message - EXO-65070

### DIFF
--- a/application/src/main/webapp/vue-app/messageFilter.js
+++ b/application/src/main/webapp/vue-app/messageFilter.js
@@ -3,7 +3,9 @@ export default function(msg, highlight, emojis) {
     return msg;
   }
   let message = '';
-  const lines = msg.split(/<br\s*\/?>/);
+  // '&lt;' represents the '<'
+  // '&gt;' represents the '>'
+  const lines = msg.split(/<br\s*\/?>|&lt;br\s*\/?&gt;/);
 
   lines.forEach( (line, index) => {
     line = $('<div />').html(line).text();


### PR DESCRIPTION
Before this change, emojis weren't recognized after a line break in the chat message. This was due to HTML character entity encoding, which encodes reserved or special characters, including the < and > characters. This change adds a regular expression to match these encoded reserved characters.