### PR TITLE
fix : Line break isn't recognized after a Blockquote - EXO-65349

### DIFF
--- a/application/src/main/webapp/vue-app/messageFilter.js
+++ b/application/src/main/webapp/vue-app/messageFilter.js
@@ -71,7 +71,7 @@ function transformQuote(quote) {
   const quoteUser = quote.slice(QUOTE_START.length, quote.indexOf(']'));
   const quoteContent = quote.slice(quote.indexOf(']') + 1, quote.indexOf(QUOTE_END)).trim();
  
-  quote = `<blockquote><span class="quote-user-name">${quoteUser}:</span>${quoteContent}</blockquote>`;
+  quote = `<div><blockquote><span class="quote-user-name">${quoteUser}:</span>${quoteContent}</blockquote></div>`;
 
   return quote;
 }


### PR DESCRIPTION
Prior to this change, a line break wasn't recognized after a blockquote chat message. This change includes the blockquote tag inside a div tag, resolving this issue.