### PR TITLE
feat : Move deprecated juzu dependencies from meeds-io to exo - EXO-66190 - meeds-io/MIPs#79

### DIFF
--- a/packaging/standalone-client-packaging/src/main/assemblies/standalone-client-packaging.xml
+++ b/packaging/standalone-client-packaging/src/main/assemblies/standalone-client-packaging.xml
@@ -53,6 +53,22 @@
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
+    <dependencySet>
+      <outputDirectory>${file.separator}</outputDirectory>
+      <includes>
+        <include>org.exoplatform.commons-exo:commons-juzu:jar</include>
+        <include>org.juzu:*:jar</include>
+        <include>aopalliance:aopalliance:jar</include>
+        <include>com.google.inject:guice:jar</include>
+        <include>org.hibernate:hibernate-validator:jar</include>
+        <include>org.mozilla:rhino:jar</include>
+        <include>javax.validation:validation-api:jar</include>
+        <include>org.webjars:webjars-locator:jar</include>
+
+      </includes>
+      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
   </dependencySets>
   <fileSets>
     <fileSet>

--- a/server-standalone/pom.xml
+++ b/server-standalone/pom.xml
@@ -49,7 +49,7 @@
       <artifactId>portlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.commons</groupId>
+      <groupId>org.exoplatform.commons-exo</groupId>
       <artifactId>commons-juzu</artifactId>
       <exclusions>
         <exclusion>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -99,10 +99,14 @@
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
-      <dependency>
-          <groupId>org.exoplatform.social</groupId>
-          <artifactId>social-component-notification</artifactId>
-      </dependency>
+    <dependency>
+        <groupId>org.exoplatform.social</groupId>
+        <artifactId>social-component-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons-exo</groupId>
+      <artifactId>commons-juzu</artifactId>
+    </dependency>
     <!-- swagger -->
     <dependency>
       <groupId>io.swagger.core.v3</groupId>


### PR DESCRIPTION
Juzu dependency is deprecated in meeds.
We still need it for chat, rh-management and customer space. We move it in eXo side waiting the refactor of these components.