### PR TITLE
fix : fix css regression on chat - EXO-66336

### DIFF
--- a/application/src/main/webapp/css/components/chatMessage.less
+++ b/application/src/main/webapp/css/components/chatMessage.less
@@ -43,7 +43,7 @@
   }
 }
 
-.chat-message-box {
+#chats .chat-message-box {
   display: flex;
   margin-top: 20px;
   .chat-sender-avatar, .chat-message-action {
@@ -81,7 +81,7 @@
     .flex-remaining-width;
     background: @messageBubbleColor;
     border: @defaultBorder;
-    border-radius: @messageBubbleRadius; 
+    border-radius: @messageBubbleRadius;
     padding: 12px 7px;
     position: relative;
     min-height: 20px;
@@ -114,6 +114,7 @@
       font-style: italic;
       color: @quoteTextColor;
       border-color: @quoteBarColor;
+      border-left-style: solid;
       .quote-user-name {
         display: block;
       }

--- a/application/src/main/webapp/css/emoticons.less
+++ b/application/src/main/webapp/css/emoticons.less
@@ -1,4 +1,4 @@
-.chat-emoticon {
+#chats .chat-emoticon {
   display: inline-block;
   position: relative;
   color: transparent;


### PR DESCRIPTION
Before this fix, smileys were no more displayed in chat, and left border of blockquote are not displayed This fix specialized the css for theses elements in order to increase the priority of them, so that css instructions are not override by global one in vuetify