### PR TITLE
fix : fix css regression on chat - EXO-66336 (#664)

### DIFF
--- a/application/src/main/webapp/css/emoticons.less
+++ b/application/src/main/webapp/css/emoticons.less
@@ -1,4 +1,4 @@
-#chats .chat-emoticon {
+#chats .chat-emoticon, .chat-message-composer .chat-emoticon {
   display: inline-block;
   position: relative;
   color: transparent;


### PR DESCRIPTION
Before this fix, smileys were no more displayed in chat composer This fix specialized the css for theses elements in order to increase the priority of them, so that css instructions are not override by global one in vuetify