### PR TITLE
SWF: Remove  mongodb embedded os enforcement WA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <!-- TODO check dependencies from parent pom -->
     <commons-lang3.version>3.2</commons-lang3.version>
-    <de.flapdoodle.embed.mongo.version>4.6.3</de.flapdoodle.embed.mongo.version>
+    <de.flapdoodle.embed.mongo.version>4.9.2</de.flapdoodle.embed.mongo.version>
     <commons-compress.version>1.22</commons-compress.version>
     <javax.enterprise.cdi.version>1.0-SP4</javax.enterprise.cdi.version>
     <mongodb-java-driver.version>4.9.1</mongodb-java-driver.version>

--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -151,7 +151,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_22_04 -Dchat.embeddedMongoDBVersion=6.0</argLine>
+          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dchat.embeddedMongoDBVersion=6.0</argLine>
         </configuration>
       </plugin>
 

--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -151,7 +151,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_20_04 -Dchat.embeddedMongoDBVersion=6.0</argLine>
+          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dde.flapdoodle.os.override=Linux|X86_64|Ubuntu|Ubuntu_22_04 -Dchat.embeddedMongoDBVersion=6.0</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Prior to this change, MongoDB-embedded unit tests were using an enforced OS environment which leads to manual change each time we upgrade our CI builds. A recent version of `de.flapdoodle.embed.mongo` library has fixed that issue. So no need to enforce the OS version anymore.