### PR TITLE
fix: enhance infinite loading of chat when logged out - EXO-67681 (#678)

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/chat/listener/UserLoginListener.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/UserLoginListener.java
@@ -19,7 +19,7 @@ public class UserLoginListener extends Listener<ConversationRegistry, Conversati
       return;
     }
     ServerBootstrap.saveSpaces(userId);
-    if (Boolean.valueOf(ServerBootstrap.shouldUpdate(userId))) {
+    if (Boolean.parseBoolean(ServerBootstrap.shouldUpdate(userId))) {
       ServerBootstrap.setEnabledUser(userId, true);
     }
   }


### PR DESCRIPTION
When a user is logged out , the popup to force him reconnect does not show up and we have an infinite calls to the server to retrieve user status and his rooms. This commit fixes the check of the user disconnection that was checking cometd status which is wrong as the logout event is already using the cometd channel to dispatch the event to all pages. Besides, when the eXo platform server returns a 403 error for Rest calls, it is sure that the user is logged out, then we send an event to all components of the Chat app to notify and display the login popup.