### PR TITLE
fix: scroll to full chat page - EXO-67772

### DIFF
--- a/application/src/main/webapp/css/layout.less
+++ b/application/src/main/webapp/css/layout.less
@@ -1,4 +1,9 @@
 /* Layout */
+.chatPage{
+  .PORTLET-FRAGMENT {
+    padding-bottom: 0px !important;
+  }
+} 
 #chat-application {
   height: 100vh;
   display: flex;

--- a/application/src/main/webapp/index.html
+++ b/application/src/main/webapp/index.html
@@ -1,4 +1,9 @@
 <div class="VuetifyApp">
   <div id="chatApplication">
+    <script>
+      require(['SHARED/chatBundle'], function(chatApp) {
+        chatApp.init();
+      });
+    </script>
   </div>
 </div>

--- a/extension/src/main/webapp/WEB-INF/conf/chat/portal-upgrade-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/portal-upgrade-configuration.xml
@@ -1,0 +1,54 @@
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>ExoChatPageUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <description>Replaces the old property value with the new property value</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>120</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>overview.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/chat/</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>chat</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>

--- a/extension/src/main/webapp/WEB-INF/conf/chat/portal/global/pages.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/portal/global/pages.xml
@@ -28,6 +28,7 @@
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <edit-permission>*:/platform/administrators</edit-permission>
       <show-max-window>true</show-max-window>
+      <hide-shared-layout>true</hide-shared-layout>
       <portlet-application>
          <portlet>
             <application-ref>chat</application-ref>

--- a/extension/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -10,5 +10,6 @@
   <import>war:/conf/chat/listener-configuration.xml</import>
   <import>war:/conf/chat/social-configuration.xml</import>
   <import>war:/conf/chat/notification-configuration.xml</import>
+  <import>war:/conf/chat/portal-upgrade-configuration.xml</import>
 
 </configuration>


### PR DESCRIPTION
Before this change, when you open the full chat page and scroll outside the chat area, there is a gray border at the bottom of the chat page and there is a scrolling effect when we scroll outside of the conversation area. To resolve this issue, add the hide-shared-layout property as true in the page.xml file to remove the padding added after the containner chat application and remove the padding-bottom added by the PORTLET-FRAGMENT class. After this change, no more gray border and no more scrolling effect outside the chat area.