### PR TITLE
fix: Fix Display issue where chat room messages are no longer displayed - EXO-68593

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -52,7 +52,7 @@ import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;


### PR DESCRIPTION
Prior to this change, there was a problem when attempting to parse a long from an empty toTimestamp string, as StringUtils.isNumeric(toTimestamp) returned true for an empty string, resulting in a NumberFormatException. This commit solves the problem by updating the import instruction to use org.apache.commons.lang3.StringUtils instead of org.apache.commons.lang.StringUtils. StringUtils.isNumeric now correctly checks that an empty string is not numeric, preventing long parsing attempts.