### PR TITLE
fix : menu list and call button aren't displayed - EXO-68629 

### DIFF
--- a/application/src/main/webapp/css/layout.less
+++ b/application/src/main/webapp/css/layout.less
@@ -1,5 +1,6 @@
 /* Layout */
 .chatPage{
+  max-height: 100% !important;
   .PORTLET-FRAGMENT {
     padding-bottom: 0px !important;
   }

--- a/application/src/main/webapp/index.html
+++ b/application/src/main/webapp/index.html
@@ -1,9 +1,4 @@
 <div class="VuetifyApp">
   <div id="chatApplication">
-    <script>
-      require(['SHARED/chatBundle'], function(chatApp) {
-        chatApp.init();
-      });
-    </script>
   </div>
 </div>

--- a/extension/src/main/webapp/WEB-INF/conf/chat/portal-upgrade-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/portal-upgrade-configuration.xml
@@ -3,7 +3,7 @@
   <external-component-plugins>
     <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
     <component-plugin>
-      <name>ExoChatPageUpgrade</name>
+      <name>ExoChatPageUpgradeV1</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
       <description>Replaces the old property value with the new property value</description>

--- a/extension/src/main/webapp/WEB-INF/conf/chat/portal/global/pages.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/portal/global/pages.xml
@@ -28,7 +28,6 @@
       <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
       <edit-permission>*:/platform/administrators</edit-permission>
       <show-max-window>true</show-max-window>
-      <hide-shared-layout>true</hide-shared-layout>
       <portlet-application>
          <portlet>
             <application-ref>chat</application-ref>


### PR DESCRIPTION
Prior to this change, the call button and the room action list were not being displayed. The problem was that the shared layout on the chat page was hidden, which caused issues with loading modules like bts-dropdown and webconferencingCallButton. This PR makes sure to not hide the shared layout from the chat page and address the scrolling problem !