### PR TITLE
fix: Fix add the file_drop module to exo commons resources - EXO-68825

### DIFF
--- a/application/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/application/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -90,7 +90,7 @@
             <module>iphoneStyleCheckbox</module>
         </depends>
         <depends>
-            <module>filedrop</module>
+            <module>file_drop</module>
         </depends>
         <depends>
             <module>bts_tooltip</module>


### PR DESCRIPTION
Prior to this change, after moving the filedrop module from the commons to the perk-store addon, by uninstalling the perk-store addon from the exo server, we were not able to add an illustration to the news or drop a file on the chat application. This change is going to add the file_drop module to exo commons resources resources to resolve this issue.