### PR TITLE
fix: @ in message resets the format - EXO-69693.

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -265,7 +265,15 @@ export default {
     sendMessage() {
       let newMessage = this.$refs.messageComposerArea.innerHTML;
       if (newMessage.indexOf('@') > -1) {
-        newMessage = this.checkMention(newMessage);
+        const tab = newMessage.split('<br>');
+        newMessage = '';
+        for (const elm of tab) {
+          let element = elm;
+          if (element.indexOf('@') > -1) {
+            element = this.checkMention(element);
+          }
+          newMessage = newMessage.concat(element).concat('<br>');
+        }
       }
       if (!newMessage || !newMessage.trim()) {
         return;


### PR DESCRIPTION
Before this change, when type a message having multiple line and add @ anywhere in message and send message. After this change, this message is sent and displayed correctly.