### PR TITLE
fix: Disable/enable space chat - EXO-69969

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -276,6 +276,10 @@ public class ChatServer extends ChatTools {
       deleteTeamRoom(req, resp);
       break;
     }
+    case "/updateRoomEnabled": {
+      setRoomEnabled(req, resp);
+      break;
+    }
     default:
       writeTextResponse(resp, null, HttpStatus.SC_NOT_FOUND);
     }


### PR DESCRIPTION
Before this change, when send messages in spacesX room and in spaceX settings disable chat and refresh, chat is enabled after refresh. After this change, chat remains disabled after refresh.

(cherry picked from commit f20428da32f5d342675b7167eb35d11a734fa94f)