### PR TITLE
fix: Chat dropdown menu do not open if user is not administrator - EXO-70319

### DIFF
--- a/application/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/application/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -96,6 +96,9 @@
             <module>bts_tooltip</module>
         </depends>
         <depends>
+            <module>bts_dropdown</module>
+        </depends>
+        <depends>
             <module>fetchPolyfill</module>
         </depends>
         <depends>


### PR DESCRIPTION
Before this fix, all dropdown menu does not opens in chat page This is because the js module bts_dropdown is not loaded on this page when I am administrators It was loaded before wy other js module, which were recently cleaned.

This commit add module bts_dropdown as dependency of chat module