### PR TITLE
fix: [Chat] message form not preserved on edit message - EXO-70366 .

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -173,6 +173,7 @@ export default {
     document.addEventListener(chatConstants.ACTION_MESSAGE_DELETE, this.putFocusOnComposer);
     document.addEventListener(chatConstants.ACTION_MESSAGE_QUOTE, this.quoteMessage);
     this.$root.$on('edit-chat-message', messageToEdit => {
+      messageToEdit.msg = messageToEdit.msg.replaceAll('\n','<br>');
       this.chatMessage = messageToEdit;
       this.$refs.messageComposerArea.innerHTML = this.chatMessage.msg;
       this.putFocusOnComposer();


### PR DESCRIPTION
Before this change, when send a message which has several line breaks and edit the message, on edit, the message form isn't displayed. After this change, on edit, the message form should be maintained.