### PR TITLE
fix: Text replacement with copy/paste doesn't work anymore on Chat Message composer. - EXO-53350

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -428,9 +428,22 @@ export default {
         // cancel paste
         e.preventDefault();
         // get text representation of clipboard
-        this.text = this.encodeHTMLEntities((e.originalEvent || e).clipboardData.getData('text/plain'));
+        const pastedText = document.createTextNode((e.originalEvent || e).clipboardData.getData('text/plain'));
         // insert text manually
-        $(this.$refs.messageComposerArea).insertAtCaret(this.text);
+        const selection = window.getSelection();
+        const range = selection.getRangeAt(0);
+        if (selection.toString()) {
+          range.deleteContents();
+          range.insertNode(pastedText);
+        } else {
+          range.insertNode(pastedText);
+        }
+        if (pastedText) {
+          range.setStartAfter(pastedText);
+          range.setEndAfter(pastedText);
+        }
+        selection.removeAllRanges();
+        selection.addRange(range);
       }
     },
   }


### PR DESCRIPTION
Before this change, copy text (Ctrl + C), paste it (Ctrl + V) in chat box. select all text in composer (Ctrl + A) and paste text again (Ctrl + V), text not replaced but duplicated. After this change, the images are easily resized regardless of their original size.

(cherry picked from commit 7e19ae524ac95d3c6104969f50eed6764f0821f6)