### PR TITLE
fix: Update to JDK21 - EXO-71474 - Meeds-io/MIPs#91

### DIFF
--- a/server-embedded/pom.xml
+++ b/server-embedded/pom.xml
@@ -125,7 +125,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -Dchat.embeddedMongoDBVersion=6.0</argLine>
+          <argLine>@{surefire.argLine} -Dchat.embeddedMongoDBVersion=6.0</argLine>
         </configuration>
       </plugin>
 

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/CometdConfigurationServlet.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/CometdConfigurationServlet.java
@@ -12,7 +12,6 @@ import org.exoplatform.chat.listener.GuiceManager;
 import org.exoplatform.chat.services.RealTimeMessageService;
 import org.exoplatform.chat.services.TokenService;
 import org.exoplatform.chat.utils.PropertyManager;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.RootContainer;
@@ -223,7 +222,7 @@ public class CometdConfigurationServlet extends AnnotationCometDServlet {
     public Enumeration<String> getInitParameterNames() {
       if (configs == null) {
         List<String> keys = new LinkedList<String>();
-        Properties props = PrivilegedSystemHelper.getProperties();
+        Properties props = System.getProperties();
         int len = PREFIX.length();
 
         for (Object key : props.keySet()) {


### PR DESCRIPTION
Remove usage of SecurityManager as it is deprecated for removal in jdk21 Remove also usage of classes
- SecurityHelper
- PrivilegedSystemHelper
- PrivilegedFileHelper
- SecureList
- SecureSet
- SecureCollections

These classes are here only to use securityManager, and as it is removed, it is no more necessary