### PR TITLE
fix: bad display of content and can't send the message through side button - EXO-71791 .

### DIFF
--- a/application/src/main/webapp/css/components/messageComposer.less
+++ b/application/src/main/webapp/css/components/messageComposer.less
@@ -47,6 +47,8 @@
   #messageComposerArea {
     width: 100% !important;
     padding: 3px 10px;
+    line-break: anywhere !important;
+    overflow-y: auto !important;
   }
   #messageComposerArea:focus {
     outline: none;


### PR DESCRIPTION
Before this change, when, open chat drawer, paste a copied link 2 times with no break line, click outside the text area and try to send the message through the side button, the text in overlap with the button + the message can't be feels. After this change, the msg does not cross the text area + is able to send.