### PR TITLE
fix: bad display of content and can't send the message through side button - EXO-71791 .

### DIFF
--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -18,7 +18,9 @@
     <div class="composer-container">
       <div class="composer-box">
         <div v-if="!miniChat" class="composer-action">
-          <div class="action-emoji">
+          <div
+            v-if="mq!=='mobile'"
+            class="action-emoji">
             <i
               v-exo-tooltip.top="$t('exoplatform.chat.emoji.tip')"
               class="uiIconChatSmile"


### PR DESCRIPTION
Before this change, when, open chat drawer, paste a copied link 2 times with no break line, click outside the text area and try to send the message through the side button, the text in overlap with the button + the message can't be feels. After this change, the msg does not cross the text area + is able to send.