### PR TITLE
fix: bad display of content and can't send the message through Send button - EXO-71791

### DIFF
--- a/application/src/main/webapp/css/components/messageComposer.less
+++ b/application/src/main/webapp/css/components/messageComposer.less
@@ -47,6 +47,8 @@
   #messageComposerArea {
     width: 100% !important;
     padding: 3px 10px;
+    line-break: anywhere !important;
+    overflow-y: auto !important;
   }
   #messageComposerArea:focus {
     outline: none;

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -18,7 +18,9 @@
     <div class="composer-container">
       <div class="composer-box">
         <div v-if="!miniChat" class="composer-action">
-          <div class="action-emoji">
+          <div
+            v-if="mq!=='mobile'"
+            class="action-emoji">
             <i
               v-exo-tooltip.top="$t('exoplatform.chat.emoji.tip')"
               class="uiIconChatSmile"


### PR DESCRIPTION
Before this change, on chat drawer, paste a copied link 2 times with no break line and clicking outside the text area makes the message impossible to be sent as the text overlaps with the button +. 
After this change, the message does not cross the text area border and can be sent.