### PR TITLE
fix: Send a message - Word is displayed on two lines - EXO-72068.

### DIFF
--- a/application/src/main/webapp/css/components/messageComposer.less
+++ b/application/src/main/webapp/css/components/messageComposer.less
@@ -47,7 +47,6 @@
   #messageComposerArea {
     width: 100% !important;
     padding: 3px 10px;
-    line-break: anywhere !important;
     overflow-y: auto !important;
   }
   #messageComposerArea:focus {

--- a/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
+++ b/application/src/main/webapp/vue-app/components/ExoChatMessageComposer.vue
@@ -48,6 +48,7 @@
           ref="messageComposerArea"
           name="messageComposerArea"
           type="text"
+          class="text-break"
           autofocus
           @keydown.enter="preventDefault"
           @keypress.enter="preventDefault"
@@ -58,6 +59,7 @@
           ref="messageComposerArea"
           contenteditable="true"
           name="messageComposerArea"
+          class="text-break"
           @keydown.enter="checkIfMentioning"
           @keypress.enter="preventDefault"
           @keyup.enter="sendMessageWithKey"


### PR DESCRIPTION
Before this change, when send a message in chat that has two or three lines, some words are displayed on two lines. After this change, Words is displayed in one line.