### PR TITLE
fix: chat button extension should be available for enabled users - Meeds-io/meeds#2155 - EXO-72345

### DIFF
--- a/application/src/main/webapp/vue-app/extension.js
+++ b/application/src/main/webapp/vue-app/extension.js
@@ -439,7 +439,7 @@ export function registerExternalExtensions(chatTitle) {
     class: 'fas fa-comments',
     additionalClass: 'mt-1',
     order: 10,
-    enabled: () => true,
+    enabled: (user) => user?.enabled,
     click: (profile) => {
       const chatType = profile.groupId ? 'space-id' : 'username';
       const chatRoomName = profile.prettyName ? profile.id : profile.username;


### PR DESCRIPTION

Before this fix, the chat button was available for all users, even those who are disabled. The fix restricts the chat button to be displayed just for enabled users in their card inside people page and space Members page