### PR TITLE
fix: remove unwanted bottom margin for chat application - EXO-73517

### DIFF
--- a/application/src/main/webapp/css/layout.less
+++ b/application/src/main/webapp/css/layout.less
@@ -3,6 +3,7 @@
   max-height: 100% !important;
   .PORTLET-FRAGMENT {
     padding-bottom: 0px !important;
+    margin-bottom:0px;
   }
 }
 


### PR DESCRIPTION
Before this fix, there is a unwanted bottom margin. This is due to the fact that chat application page is loaded with the topbar (because of some needed addons dependencies). For the moment, we add a css rules to set this margin bottom correctly.