### PR TITLE
fix: chat :  no chat notifications if user is idle for few days - EXO-69418

### DIFF
--- a/common/src/main/java/org/exoplatform/chat/utils/PropertyManager.java
+++ b/common/src/main/java/org/exoplatform/chat/utils/PropertyManager.java
@@ -110,6 +110,8 @@ public class PropertyManager {
 
   public static final String PROPERTY_REQUEST_TIMEOUT = "request.timeout";
 
+  public static final String PROPERTY_NOTIFICATION_DAYS_TO_LIVE = "chat.notifications.days.toLive";
+
   public static String getProperty(String key)
   {
     String value = (String)properties().get(key);

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/NotificationMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/NotificationMongoDataStorage.java
@@ -33,6 +33,7 @@ import org.exoplatform.chat.model.RoomBean;
 import org.exoplatform.chat.services.ChatService;
 import org.exoplatform.chat.services.NotificationDataStorage;
 import org.exoplatform.chat.services.UserService;
+import org.exoplatform.chat.utils.PropertyManager;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.json.JSONException;
@@ -68,7 +69,16 @@ public class NotificationMongoDataStorage implements NotificationDataStorage
 
   public static void cleanupNotifications() {
     MongoCollection<Document> coll = ConnectionManager.getInstance().getDB().getCollection(M_NOTIFICATIONS);
-    Bson query = Filters.lt(TIMESTAMP, System.currentTimeMillis() - 24*60*60*1000);
+    long daysToLive = 30;
+    String daysToLiveProp = PropertyManager.getProperty(PropertyManager.PROPERTY_NOTIFICATION_DAYS_TO_LIVE);
+    if (!StringUtils.isBlank(daysToLiveProp)) {
+      try {
+        daysToLive = Long.parseLong(daysToLiveProp);
+      } catch (NumberFormatException e) {
+        LOG.warn("value set as chat notifications days to live is not a number, the default value will be used");
+      }
+    }
+    Bson query = Filters.lt(TIMESTAMP, System.currentTimeMillis() - 24*60*60*1000*daysToLive);
     coll.deleteMany(query);
   }
 


### PR DESCRIPTION
Before this fix,  no chat notifications if user is idle for few days. This is due to the clean notification job that removes all chat notifications not seen for 24 for our

This commit add a new chat property (chat.notifications.days.toLive) to define the number of days to live for notifications and set a default value of 30 days.