### PR TITLE
fix: Restore displaying chat icon in space drawer options - EXO-75690

### DIFF
--- a/application/src/main/webapp/vue-app/components/PopoverChatButton.vue
+++ b/application/src/main/webapp/vue-app/components/PopoverChatButton.vue
@@ -43,7 +43,7 @@ export default {
       chatServices.getUserSettings().then(userSettings => {
         this.userSettings = userSettings;
         this.$spaceService.isSpaceMember(this.identityId, this.userSettings.username).then(data => {
-          if (data.isMember === 'true') {
+          if (data) {
             chatServices.isRoomEnabled(this.userSettings, this.identityId).then(value => {
               this.spaceChatEnabled = value === 'true';
             });


### PR DESCRIPTION
Prior to this fix, the chat icon in space drawer is not dispalyed any more, this is due to a change on the js spaceService.isSpaceMember method that was changed to return true or false instead of an object with isMember property.

This commit update the popover chat button code according to the changes done on the space service.