### PR TITLE
fix : Administrators are added in spaces they are not members - EXO-76387

### DIFF
--- a/common/src/main/java/org/exoplatform/chat/services/UserService.java
+++ b/common/src/main/java/org/exoplatform/chat/services/UserService.java
@@ -88,6 +88,8 @@ public interface UserService
 
   public void setSpaces(String user, List<SpaceBean> spaces);
 
+  public void removeUserFromSpace(String user, SpaceBean space);
+
   public void addTeamRoom(String user, String teamRoomId);
 
   public void addTeamUsers(String teamRoomId, List<String> users);

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -268,6 +268,10 @@ public class ChatServer extends ChatTools {
       setSpaces(req, resp);
       break;
     }
+    case "/removeUserFromSpace": {
+      removeUserFromSpace(req, resp);
+      break;
+    }
     case "/delete": {
       delete(req, resp);
       break;

--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatTools.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatTools.java
@@ -33,6 +33,7 @@ import org.apache.http.HttpStatus;
 import org.exoplatform.chat.listener.ConnectionManager;
 import org.exoplatform.chat.listener.GuiceManager;
 import org.exoplatform.chat.model.RealTimeMessageBean;
+import org.exoplatform.chat.model.SpaceBean;
 import org.exoplatform.chat.model.SpaceBeans;
 import org.exoplatform.chat.model.UserBean;
 import org.exoplatform.chat.services.ChatException;
@@ -316,6 +317,25 @@ abstract class ChatTools extends HttpServlet {
 
     writeTextResponse(response, "OK");
   }
+  protected void removeUserFromSpace(HttpServletRequest request, HttpServletResponse response) {
+    String username = request.getParameter(USERNAME_PARAM);
+    String space = request.getParameter("space");
+    String passphrase = request.getParameter(PASSPHRASE_PARAM);
+    if (!checkPassphrase(passphrase)) {
+      writeJsonResponse(response, PASSPHRASE_DOESN_T_MATCH_MESSAGE, HttpStatus.SC_NOT_FOUND);
+      return;
+    }
+
+    try {
+      SpaceBean spaceBean = (SpaceBean) ChatUtils.fromString(space);
+      userService.removeUserFromSpace(username, spaceBean);
+    } catch (IOException | ClassNotFoundException e) {
+      LOG.warning(e.getMessage());
+    }
+
+    writeTextResponse(response, "OK");
+  }
+
 
   protected void getUserFullName(HttpServletRequest request, HttpServletResponse response) {
     String username = request.getParameter(USERNAME_PARAM);

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/UserDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/UserDataStorage.java
@@ -84,6 +84,7 @@ public interface UserDataStorage {
   }
 
   void setSpaces(String user, List<SpaceBean> spaces);
+  void removeUserFromSpace(String user, SpaceBean space);
 
   void addTeamRoom(String user, String teamRoomId);
 

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/UserServiceImpl.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/UserServiceImpl.java
@@ -148,6 +148,10 @@ public class UserServiceImpl implements UserService {
     userStorage.setSpaces(user, spaces);
   }
 
+  public void removeUserFromSpace(String user, SpaceBean space) {
+    userStorage.removeUserFromSpace(user, space);
+  }
+
   public void addTeamRoom(String user, String teamRoomId) {
     userStorage.addTeamRoom(user, teamRoomId);
 

--- a/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/services/mongodb/UserMongoDataStorage.java
@@ -24,6 +24,7 @@ import com.mongodb.*;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import org.apache.commons.lang3.StringUtils;
@@ -462,6 +463,26 @@ public class UserMongoDataStorage implements UserDataStorage {
       doc.append(IS_ENABLED, Boolean.toString(true));
       doc.append(IS_DELETED, Boolean.toString(false));
       usersCollection.insertOne(doc);
+    }
+  }
+
+  @Override
+  public void removeUserFromSpace(String user, SpaceBean space) {
+    String spaceRoomId =ChatUtils.getRoomId(space.getId());
+    MongoCollection<Document> coll = db().getCollection(M_USERS_COLLECTION);
+    BasicDBObject query = new BasicDBObject();
+    query.put(USER, user);
+    MongoCursor<Document> cursor = coll.find(query).cursor();
+    if (cursor.hasNext()) {
+      Document doc = cursor.next();
+      if (doc.containsKey(SPACES)) {
+        List<String> spaces = (List<String>) doc.get(SPACES);
+        if (spaces.contains(spaceRoomId)) {
+          spaces.remove(spaceRoomId);
+          doc.put(SPACES, spaces);
+          coll.replaceOne(query, doc);
+        }
+      }
     }
   }
 

--- a/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/listener/ServerBootstrap.java
@@ -35,6 +35,7 @@ import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.space.SpaceFilter;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
@@ -56,8 +57,20 @@ public class ServerBootstrap {
     return callServer("users", "user=" + username + "&room=" + room + "&token=" + token);
   }
 
+  public static String getUsersWithLimit(String username, String token, String room, int limit) {
+    return callServer("users", "user=" + username + "&room=" + room + "&token=" + token + "&limit="+limit);
+  }
+
+  public static String getUserCount(String username, String token, String room) {
+    return callServer("usersCount", "user=" + username + "&room=" + room + "&token=" + token);
+  }
+
   public static String getRoom(String username, String token, String room) {
     return callServer("getRoom", "user=" + username + "&room=" + room + "&targetUser=" + room + "&token=" + token + "&withDetail=true");
+  }
+
+  public static String getSpaceRoom(String username, String token, String spaceName) {
+    return callServer("getRoom", "user=" + username + "&targetUser=" + spaceName + "&type=space-id&token=" + token + "&withDetail=true");
   }
 
   public static String getUserFullName(String username) {
@@ -114,7 +127,7 @@ public class ServerBootstrap {
   public static void saveSpaces(String username) {
     try {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
-      ListAccess<Space> spacesListAccess = spaceService.getAccessibleSpacesWithListAccess(username);
+      ListAccess<Space> spacesListAccess = spaceService.getMemberSpacesByFilter(username,new SpaceFilter());
       List<Space> spaces = Arrays.asList(spacesListAccess.load(0, spacesListAccess.getSize()));
       ArrayList<SpaceBean> beans = new ArrayList<>();
       for (Space space : spaces) {
@@ -132,6 +145,25 @@ public class ServerBootstrap {
     }
   }
 
+  public static void removeUserFromSpace(String username, String spaceId) {
+    try {
+      SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
+      Space space = spaceService.getSpaceById(spaceId);
+      if (space != null) {
+        SpaceBean spaceBean = new SpaceBean();
+        spaceBean.setDisplayName(space.getDisplayName());
+        spaceBean.setGroupId(space.getGroupId());
+        spaceBean.setId(space.getId());
+        spaceBean.setShortName(space.getShortName());
+        spaceBean.setPrettyName(space.getPrettyName());
+        removeUserFromSpace(username, spaceBean);
+
+      }
+    } catch (Exception e) {
+      LOG.warn("Error while removing user from spaces'" + username + "'", e);
+    }
+  }
+
   public static void setSpaces(String username, SpaceBeans beans) {
     String params = "username=" + username;
     String serSpaces = "";
@@ -143,6 +175,19 @@ public class ServerBootstrap {
     }
     params += "&spaces=" + serSpaces;
     postServer("setSpaces", params);
+  }
+
+  public static void removeUserFromSpace(String username, SpaceBean bean) {
+    String params = "username=" + username;
+    String serSpace = "";
+    try {
+      serSpace = ChatUtils.toString(bean);
+      serSpace = URLEncoder.encode(serSpace, "UTF-8");
+    } catch (IOException e) {
+      LOG.error("Error encoding spaces", e);
+    }
+    params += "&space=" + serSpace;
+    postServer("removeUserFromSpace", params);
   }
 
   private static String callServer(String serviceUri, String params) {

--- a/services/src/main/java/org/exoplatform/addons/chat/upgrade/ChatSpacesAdministratorsUpgradePlugin.java
+++ b/services/src/main/java/org/exoplatform/addons/chat/upgrade/ChatSpacesAdministratorsUpgradePlugin.java
@@ -1,0 +1,129 @@
+package org.exoplatform.addons.chat.upgrade;
+
+import org.exoplatform.addons.chat.listener.ServerBootstrap;
+import org.exoplatform.commons.upgrade.UpgradePluginExecutionContext;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.space.SpaceFilter;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.ws.frameworks.cometd.ContinuationService;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+
+public class ChatSpacesAdministratorsUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log log = ExoLogger.getExoLogger(ChatSpacesAdministratorsUpgradePlugin.class);
+
+  private SpaceService        spaceService;
+  private   ContinuationService continuationService;
+  private String superUser;
+  private String superUserChatToken;
+  private int                 LIMIT = 100;
+
+  public ChatSpacesAdministratorsUpgradePlugin(InitParams initParams, SpaceService spaceService,UserACL userACL, ContinuationService continuationService) {
+    super(initParams);
+    this.spaceService=spaceService;
+    this.continuationService=continuationService;
+
+    this.superUser = userACL.getSuperUser();
+    this.superUserChatToken = ServerBootstrap.getToken(this.superUser);
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    long startupTime = System.currentTimeMillis();
+    log.info("Start Remove Space administrator from all space chat room");
+
+    boolean chatServerStarted = false;
+    int nbTest = 0;
+    while (!chatServerStarted && nbTest<100) {
+      try {
+        Thread.sleep(500);
+      } catch (Exception e2) {
+        //do nothing
+      }
+      nbTest++;
+      log.debug("Test if chatServer is running ({} times)", nbTest);
+      String result = ServerBootstrap.getStatus(this.superUser, this.superUserChatToken, this.superUser);
+      if (result!=null) {
+        chatServerStarted=true;
+      }
+    }
+
+    try {
+      ListAccess<Space> allSpaces = spaceService.getAllSpacesByFilter(new SpaceFilter());
+      int current = 0;
+
+      do {
+          Space[] spaces = allSpaces.load(current, LIMIT);
+          Arrays.stream(spaces).forEach(space -> checkSpace(space));
+          current+=spaces.length;
+          log.info("Run upgrade on {}/{} spaces",current,allSpaces.getSize());
+      } while (current<allSpaces.getSize());
+    } catch (Exception e) {
+      log.error("Unable to treat all spaces",e);
+      throw new RuntimeException(e);
+    }
+    log.info("End Remove Space administrator from all space chat room, execution time={}ms",
+             System.currentTimeMillis() - startupTime);
+
+  }
+
+  private void checkSpace(Space space) {
+    String spaceString = ServerBootstrap.getSpaceRoom(this.superUser, this.superUserChatToken, space.getId());
+    log.debug("Check space {}, result={}",space.getPrettyName(), spaceString);
+    if (spaceString != null) {
+      JSONObject jsonSpace = new JSONObject(spaceString);
+      if (jsonSpace.has("user")) {
+        String spaceRoomId = jsonSpace.getString("user");
+        String userCountInSpace = ServerBootstrap.getUserCount(this.superUser,this.superUserChatToken,spaceRoomId);
+        if (userCountInSpace != null) {
+          JSONObject jsonCountUsers = new JSONObject(userCountInSpace);
+          if (jsonCountUsers.has("usersCount")) {
+            int spaceUserCount = jsonCountUsers.getInt("usersCount");
+            log.debug("Space Room with name {} and id {} has {} users", spaceRoomId, space.getPrettyName(), spaceUserCount);
+            String usersInSpaceRoom = ServerBootstrap.getUsersWithLimit(this.superUser,this.superUserChatToken, spaceRoomId,spaceUserCount);
+            JSONObject users = new JSONObject(usersInSpaceRoom);
+            if (users.has("users")) {
+              checkUsers(users.getJSONArray("users"),space);
+              if (spaceUserCount != users.getJSONArray("users").length()) {
+                checkUser(space,this.superUser);
+              }
+            }
+          }
+
+        }
+      }
+
+    }
+  }
+
+  private void checkUsers(JSONArray users, Space space) {
+    for (int i=0; i<users.length();i++) {
+      JSONObject user = users.getJSONObject(i);
+      String username = user.getString("name");
+      checkUser(space, username);
+    }
+
+  }
+
+  private void checkUser(Space space, String username) {
+    if (!spaceService.isMember(space, username)) {
+      log.debug("User {} is member of space room, but not member of space {}, remove it from the space room", username, space.getPrettyName());
+      ServerBootstrap.removeUserFromSpace(username,space.getId());
+    }
+  }
+
+  public boolean shouldProceedToUpgrade(String newVersion, String previousGroupVersion, UpgradePluginExecutionContext previousUpgradePluginExecution) {
+    int executionCount = previousUpgradePluginExecution == null ? 0 : previousUpgradePluginExecution.getExecutionCount();
+    return !isExecuteOnlyOnce() || executionCount == 0;
+  }
+
+}

--- a/services/src/main/resources/conf/portal/configuration.xml
+++ b/services/src/main/resources/conf/portal/configuration.xml
@@ -66,5 +66,40 @@
         </init-params>
         </component-plugin>
     </external-component-plugins>
-
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+        <component-plugin  profiles="chat">
+            <name>ChatSpacesAdministratorsUpgradePlugin</name>
+            <set-method>addUpgradePlugin</set-method>
+            <type>org.exoplatform.addons.chat.upgrade.ChatSpacesAdministratorsUpgradePlugin</type>
+            <description>Check and fix administrators space room</description>
+            <init-params>
+                <value-param>
+                    <name>product.group.id</name>
+                    <description>The groupId of the product</description>
+                    <value>org.exoplatform.platform</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.target.version</name>
+                    <description>The plugin target version of selected groupId</description>
+                    <value>7.0.0</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.execution.order</name>
+                    <description>The plugin execution order</description>
+                    <value>10</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.execute.once</name>
+                    <description>The plugin must be executed only once</description>
+                    <value>true</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.async.execution</name>
+                    <description>The plugin will be executed in an asynchronous mode</description>
+                    <value>true</value>
+                </value-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
 </configuration>


### PR DESCRIPTION
Before this fix, platform administrators are added in chat space room for all spaces. This problem comes from the chat login listener which get 'accessible' spaces of users. With recents changes, accessibles spaces are spaces with template user can administrate. User must be only added in space he is member. To fix it, we replace the call in listener to getMemberSpacesByFilter instead of getAccessibleSpaces

In addition, to fix current data, we add an Upgrade Plugin which check all space rooms and remove users which are not member of the space