### PR TITLE
feat: Rename Dynamic container to include gtmpl only once in page - MEED-8323 - Meeds-io/MIPs#175

### DIFF
--- a/extension/src/main/webapp/WEB-INF/conf/chat/container-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/container-configuration.xml
@@ -38,7 +38,7 @@
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>bottom-end-container</value>
+          <value>body-end-container</value>
         </value-param>
         <object-param>
           <name>ChatNotificationApplication</name>

--- a/extension/src/main/webapp/WEB-INF/conf/chat/container-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/chat/container-configuration.xml
@@ -38,7 +38,7 @@
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>bottom-all-container</value>
+          <value>bottom-end-container</value>
         </value-param>
         <object-param>
           <name>ChatNotificationApplication</name>


### PR DESCRIPTION
Due to changes made in Site Layout Editor MIP, the page structure changed to move the 'bottom-all-container' addon container into UIPortalApplication.gtmpl. This change is mainly made to not having to include this dynamic container inside Standalone pages (which hides shared and site layouts) in order to have the same behavior as if the page is retrieved inside the shared layout. This dynamic container, further more, has been renamed in order to avoid having duplication of applications definition inside a same page which had defined its layout before this change (in which case, the addon container will be rendered in UIPortalApplication and the page content as well).