### PR TITLE
fix: unwanted margin in chat application - EXO-76968

### DIFF
--- a/application/src/main/webapp/css/components/chat.less
+++ b/application/src/main/webapp/css/components/chat.less
@@ -242,3 +242,8 @@
 .uiIconChatEdit:before {
   content: "\e9e4";
 }
+
+#UISiteBody:has(#chat-application) {
+   margin-left: 0px !important;
+   max-height: calc(var(--100vh, 100vh)) !important;
+}


### PR DESCRIPTION
Before this fix, there is unwanted margin in chat application This is due to the fact that chat app do not use <show-max-window> (it cannot due to technical limitation)