### PR TITLE
fix: Documents added in chat group not available for all members - EXO-78701

### DIFF
--- a/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
+++ b/server-embedded/src/main/java/org/exoplatform/chat/server/ChatServer.java
@@ -1187,7 +1187,7 @@ public class ChatServer extends ChatTools {
     }
 
     boolean showOnlyOnlineUsers = StringUtils.isNotBlank(onlineOnly) && "true".equals(onlineOnly);
-    int limit = StringUtils.isNumeric(limitString) ? Integer.parseInt(limitString) : 20;
+    int limit = StringUtils.isNumeric(limitString) ? Integer.parseInt(limitString) : 0;
     List<String> onlineUserList = StringUtils.isNotBlank(onlineUsers) ? Arrays.asList(onlineUsers.split(",")) : null;
     List<UserBean> users = userService.getUsers(room, onlineUserList, filter, limit, showOnlyOnlineUsers);
     if (StringUtils.isNotBlank(user)) {


### PR DESCRIPTION
Before this change, when Create chat group having more than 20 users then share a document in this chat and check uploaded documents permissions, only 18 users are listed in collaborators who can view the document. To fix this problem, change limit 20 to 0 when the limit is not specified to return all the room user list. After this change, all group members can open the uploaded document.

(cherry picked from commit 6976245aaf3fb2d920186efc72ec9e057c2d6727) (cherry picked from commit 16dd940c95264a3b8de10ae9bed7b9487884646a)